### PR TITLE
Update target framework to .NET 9.0 across projects

### DIFF
--- a/samples/Samples.Common/Samples.Common.csproj
+++ b/samples/Samples.Common/Samples.Common.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/samples/Sdk.ConsoleApp/Sdk.ConsoleApp.csproj
+++ b/samples/Sdk.ConsoleApp/Sdk.ConsoleApp.csproj
@@ -2,7 +2,7 @@
 
 	<PropertyGroup>
 		<OutputType>Exe</OutputType>
-		<TargetFramework>net8.0-windows</TargetFramework>
+		<TargetFramework>net9.0-windows</TargetFramework>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<PlatformTarget>x86</PlatformTarget>
 	</PropertyGroup>

--- a/samples/Sdk.Extras.ConsoleApp/Sdk.Extras.ConsoleApp.csproj
+++ b/samples/Sdk.Extras.ConsoleApp/Sdk.Extras.ConsoleApp.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0-windows</TargetFramework>
+    <TargetFramework>net9.0-windows</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <PlatformTarget>x86</PlatformTarget>

--- a/samples/Sdk.Extras.WpfApp/Sdk.Extras.WpfApp.csproj
+++ b/samples/Sdk.Extras.WpfApp/Sdk.Extras.WpfApp.csproj
@@ -2,7 +2,7 @@
 
 	<PropertyGroup>
 		<OutputType>WinExe</OutputType>
-		<TargetFramework>net8.0-windows</TargetFramework>
+		<TargetFramework>net9.0-windows</TargetFramework>
 		<UseWPF>true</UseWPF>
 		<Platforms>AnyCPU</Platforms>
 		<Version>2.3.1</Version>
@@ -60,7 +60,7 @@
 	<Target Name="RemoveDuplicateAnalyzers" BeforeTargets="CoreCompile">
 		<!-- Work around https://github.com/dotnet/wpf/issues/6792 -->
 		<ItemGroup>
-			<FilteredAnalyzer Include="@(Analyzer-&gt;Distinct())" />
+			<FilteredAnalyzer Include="@(Analyzer->Distinct())" />
 			<Analyzer Remove="@(Analyzer)" />
 			<Analyzer Include="@(FilteredAnalyzer)" />
 		</ItemGroup>

--- a/samples/Sql.ConsoleApp/Sql.ConsoleApp.csproj
+++ b/samples/Sql.ConsoleApp/Sql.ConsoleApp.csproj
@@ -2,7 +2,7 @@
 
 	<PropertyGroup>
 		<OutputType>Exe</OutputType>
-		<TargetFramework>net8.0</TargetFramework>
+		<TargetFramework>net9.0</TargetFramework>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
 	</PropertyGroup>

--- a/src/ARSoftware.Contpaqi.Comercial.Sdk.Abstractions/ARSoftware.Contpaqi.Comercial.Sdk.Abstractions.csproj
+++ b/src/ARSoftware.Contpaqi.Comercial.Sdk.Abstractions/ARSoftware.Contpaqi.Comercial.Sdk.Abstractions.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFramework>net8.0</TargetFramework>
+		<TargetFramework>net9.0</TargetFramework>
 		<Nullable>enable</Nullable>
 		<Version>6.2.1</Version>
 		<Authors>AR Software</Authors>

--- a/src/ARSoftware.Contpaqi.Comercial.Sdk.Extras/ARSoftware.Contpaqi.Comercial.Sdk.Extras.csproj
+++ b/src/ARSoftware.Contpaqi.Comercial.Sdk.Extras/ARSoftware.Contpaqi.Comercial.Sdk.Extras.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFramework>net8.0-windows</TargetFramework>
+		<TargetFramework>net9.0-windows</TargetFramework>
 		<Nullable>enable</Nullable>
 		<Version>6.2.1</Version>
 		<Authors>AR Software</Authors>

--- a/src/ARSoftware.Contpaqi.Comercial.Sdk/ARSoftware.Contpaqi.Comercial.Sdk.csproj
+++ b/src/ARSoftware.Contpaqi.Comercial.Sdk/ARSoftware.Contpaqi.Comercial.Sdk.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFramework>net8.0</TargetFramework>
+		<TargetFramework>net9.0</TargetFramework>
 		<Nullable>enable</Nullable>
 		<Version>6.2.1</Version>
 		<Authors>AR Software</Authors>

--- a/src/ARSoftware.Contpaqi.Comercial.Sql.Models/ARSoftware.Contpaqi.Comercial.Sql.Models.csproj
+++ b/src/ARSoftware.Contpaqi.Comercial.Sql.Models/ARSoftware.Contpaqi.Comercial.Sql.Models.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFramework>net8.0</TargetFramework>
+		<TargetFramework>net9.0</TargetFramework>
 		<Nullable>enable</Nullable>
 		<Version>6.2.1</Version>
 		<Authors>AR Software</Authors>

--- a/src/ARSoftware.Contpaqi.Comercial.Sql/ARSoftware.Contpaqi.Comercial.Sql.csproj
+++ b/src/ARSoftware.Contpaqi.Comercial.Sql/ARSoftware.Contpaqi.Comercial.Sql.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFramework>net8.0</TargetFramework>
+		<TargetFramework>net9.0</TargetFramework>
 		<Nullable>enable</Nullable>
 		<Version>6.2.1</Version>
 		<Authors>AR Software</Authors>

--- a/src/Sql.MigrationsStartupProject/Sql.MigrationsStartupProject.csproj
+++ b/src/Sql.MigrationsStartupProject/Sql.MigrationsStartupProject.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <ImplicitUsings>disable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>


### PR DESCRIPTION
Update target framework to .NET 9.0 across projects

- Changed target framework from .NET 8.0 to .NET 9.0 in multiple project files, including:
  - Samples.Common.csproj
  - Sdk.ConsoleApp.csproj
  - Sdk.Extras.ConsoleApp.csproj
  - Sdk.Extras.WpfApp.csproj
  - Sql.ConsoleApp.csproj
  - ARSoftware.Contpaqi.Comercial.Sdk.Abstractions.csproj
  - ARSoftware.Contpaqi.Comercial.Sdk.Extras.csproj
  - ARSoftware.Contpaqi.Comercial.Sdk.csproj
  - ARSoftware.Contpaqi.Comercial.Sql.Models.csproj
  - ARSoftware.Contpaqi.Comercial.Sql.csproj
  - Sql.MigrationsStartupProject.csproj

- Corrected syntax for `FilteredAnalyzer` in Sdk.Extras.WpfApp.csproj.
- Retained `Nullable` property as "enable" in most project files.