### PR TITLE
Release 6.3.0

### DIFF
--- a/samples/Samples.Common/Samples.Common.csproj
+++ b/samples/Samples.Common/Samples.Common.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/samples/Samples.Common/Samples.Common.csproj
+++ b/samples/Samples.Common/Samples.Common.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/samples/Sdk.ConsoleApp/Sdk.ConsoleApp.csproj
+++ b/samples/Sdk.ConsoleApp/Sdk.ConsoleApp.csproj
@@ -8,7 +8,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.0" />
+		<PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.6" />
 	
 	</ItemGroup>
 

--- a/samples/Sdk.ConsoleApp/Sdk.ConsoleApp.csproj
+++ b/samples/Sdk.ConsoleApp/Sdk.ConsoleApp.csproj
@@ -8,7 +8,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.6" />
+		<PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.10" />
 	
 	</ItemGroup>
 

--- a/samples/Sdk.ConsoleApp/Sdk.ConsoleApp.csproj
+++ b/samples/Sdk.ConsoleApp/Sdk.ConsoleApp.csproj
@@ -2,7 +2,7 @@
 
 	<PropertyGroup>
 		<OutputType>Exe</OutputType>
-		<TargetFramework>net9.0-windows</TargetFramework>
+		<TargetFramework>net10.0-windows</TargetFramework>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<PlatformTarget>x86</PlatformTarget>
 	</PropertyGroup>

--- a/samples/Sdk.ConsoleApp/Sdk.ConsoleApp.csproj
+++ b/samples/Sdk.ConsoleApp/Sdk.ConsoleApp.csproj
@@ -2,7 +2,7 @@
 
 	<PropertyGroup>
 		<OutputType>Exe</OutputType>
-		<TargetFramework>net8.0-windows</TargetFramework>
+		<TargetFramework>net9.0-windows</TargetFramework>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<PlatformTarget>x86</PlatformTarget>
 	</PropertyGroup>

--- a/samples/Sdk.Extras.ConsoleApp/Sdk.Extras.ConsoleApp.csproj
+++ b/samples/Sdk.Extras.ConsoleApp/Sdk.Extras.ConsoleApp.csproj
@@ -10,8 +10,8 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.6" />
-    <PackageReference Include="Serilog.Extensions.Hosting" Version="8.0.0" />
-    <PackageReference Include="Serilog.Sinks.Console" Version="5.0.1" />
+    <PackageReference Include="Serilog.Extensions.Hosting" Version="9.0.0" />
+    <PackageReference Include="Serilog.Sinks.Console" Version="6.0.0" />
   </ItemGroup>
  
   <ItemGroup>

--- a/samples/Sdk.Extras.ConsoleApp/Sdk.Extras.ConsoleApp.csproj
+++ b/samples/Sdk.Extras.ConsoleApp/Sdk.Extras.ConsoleApp.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0-windows</TargetFramework>
+    <TargetFramework>net9.0-windows</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <PlatformTarget>x86</PlatformTarget>

--- a/samples/Sdk.Extras.ConsoleApp/Sdk.Extras.ConsoleApp.csproj
+++ b/samples/Sdk.Extras.ConsoleApp/Sdk.Extras.ConsoleApp.csproj
@@ -9,9 +9,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.6" />
-    <PackageReference Include="Serilog.Extensions.Hosting" Version="9.0.0" />
-    <PackageReference Include="Serilog.Sinks.Console" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.10" />
+    <PackageReference Include="Serilog.Extensions.Hosting" Version="10.0.0" />
+    <PackageReference Include="Serilog.Sinks.Console" Version="6.1.1" />
   </ItemGroup>
  
   <ItemGroup>

--- a/samples/Sdk.Extras.ConsoleApp/Sdk.Extras.ConsoleApp.csproj
+++ b/samples/Sdk.Extras.ConsoleApp/Sdk.Extras.ConsoleApp.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net9.0-windows</TargetFramework>
+    <TargetFramework>net10.0-windows</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <PlatformTarget>x86</PlatformTarget>

--- a/samples/Sdk.Extras.ConsoleApp/Sdk.Extras.ConsoleApp.csproj
+++ b/samples/Sdk.Extras.ConsoleApp/Sdk.Extras.ConsoleApp.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.6" />
     <PackageReference Include="Serilog.Extensions.Hosting" Version="8.0.0" />
     <PackageReference Include="Serilog.Sinks.Console" Version="5.0.1" />
   </ItemGroup>

--- a/samples/Sdk.Extras.WpfApp/Sdk.Extras.WpfApp.csproj
+++ b/samples/Sdk.Extras.WpfApp/Sdk.Extras.WpfApp.csproj
@@ -2,7 +2,7 @@
 
 	<PropertyGroup>
 		<OutputType>WinExe</OutputType>
-		<TargetFramework>net8.0-windows</TargetFramework>
+		<TargetFramework>net9.0-windows</TargetFramework>
 		<UseWPF>true</UseWPF>
 		<Platforms>AnyCPU</Platforms>
 		<Version>2.3.1</Version>
@@ -60,7 +60,7 @@
 	<Target Name="RemoveDuplicateAnalyzers" BeforeTargets="CoreCompile">
 		<!-- Work around https://github.com/dotnet/wpf/issues/6792 -->
 		<ItemGroup>
-			<FilteredAnalyzer Include="@(Analyzer-&gt;Distinct())" />
+			<FilteredAnalyzer Include="@(Analyzer->Distinct())" />
 			<Analyzer Remove="@(Analyzer)" />
 			<Analyzer Include="@(FilteredAnalyzer)" />
 		</ItemGroup>

--- a/samples/Sdk.Extras.WpfApp/Sdk.Extras.WpfApp.csproj
+++ b/samples/Sdk.Extras.WpfApp/Sdk.Extras.WpfApp.csproj
@@ -47,9 +47,9 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="CommunityToolkit.Mvvm" Version="8.4.0" />
-		<PackageReference Include="MahApps.Metro" Version="2.4.10" />
-		<PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.6" />
+		<PackageReference Include="CommunityToolkit.Mvvm" Version="8.4.2" />
+		<PackageReference Include="MahApps.Metro" Version="2.4.11" />
+		<PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.10" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/samples/Sdk.Extras.WpfApp/Sdk.Extras.WpfApp.csproj
+++ b/samples/Sdk.Extras.WpfApp/Sdk.Extras.WpfApp.csproj
@@ -4,13 +4,7 @@
 		<OutputType>WinExe</OutputType>
 		<TargetFramework>net10.0-windows</TargetFramework>
 		<UseWPF>true</UseWPF>
-		<Platforms>AnyCPU</Platforms>
-		<Version>2.3.1</Version>
-		<Authors>AR Software</Authors>
-		<Company>AR Software</Company>
-		<Copyright>Copyright © AR Software 2022</Copyright>
 		<PlatformTarget>x86</PlatformTarget>
-		<Description>Aplicacion con ejemplos de como utilizar el SDK</Description>
 	</PropertyGroup>
 
 	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">

--- a/samples/Sdk.Extras.WpfApp/Sdk.Extras.WpfApp.csproj
+++ b/samples/Sdk.Extras.WpfApp/Sdk.Extras.WpfApp.csproj
@@ -47,7 +47,7 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="CommunityToolkit.Mvvm" Version="8.2.2" />
+		<PackageReference Include="CommunityToolkit.Mvvm" Version="8.4.0" />
 		<PackageReference Include="MahApps.Metro" Version="2.4.10" />
 		<PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.6" />
 	</ItemGroup>
@@ -55,14 +55,5 @@
 	<ItemGroup>
 	  <ProjectReference Include="..\..\src\ARSoftware.Contpaqi.Comercial.Sdk.Extras\ARSoftware.Contpaqi.Comercial.Sdk.Extras.csproj" />
 	</ItemGroup>
-
-	<!--Issue with CommunityToolkit.Mvvm v8.0.0. Test again in later version-->
-	<Target Name="RemoveDuplicateAnalyzers" BeforeTargets="CoreCompile">
-		<!-- Work around https://github.com/dotnet/wpf/issues/6792 -->
-		<ItemGroup>
-			<FilteredAnalyzer Include="@(Analyzer-&gt;Distinct())" />
-			<Analyzer Remove="@(Analyzer)" />
-			<Analyzer Include="@(FilteredAnalyzer)" />
-		</ItemGroup>
-	</Target>
+	
 </Project>

--- a/samples/Sdk.Extras.WpfApp/Sdk.Extras.WpfApp.csproj
+++ b/samples/Sdk.Extras.WpfApp/Sdk.Extras.WpfApp.csproj
@@ -2,7 +2,7 @@
 
 	<PropertyGroup>
 		<OutputType>WinExe</OutputType>
-		<TargetFramework>net9.0-windows</TargetFramework>
+		<TargetFramework>net10.0-windows</TargetFramework>
 		<UseWPF>true</UseWPF>
 		<Platforms>AnyCPU</Platforms>
 		<Version>2.3.1</Version>

--- a/samples/Sdk.Extras.WpfApp/Sdk.Extras.WpfApp.csproj
+++ b/samples/Sdk.Extras.WpfApp/Sdk.Extras.WpfApp.csproj
@@ -49,7 +49,7 @@
 	<ItemGroup>
 		<PackageReference Include="CommunityToolkit.Mvvm" Version="8.2.2" />
 		<PackageReference Include="MahApps.Metro" Version="2.4.10" />
-		<PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.0" />
+		<PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.6" />
 	</ItemGroup>
 
 	<ItemGroup>
@@ -60,7 +60,7 @@
 	<Target Name="RemoveDuplicateAnalyzers" BeforeTargets="CoreCompile">
 		<!-- Work around https://github.com/dotnet/wpf/issues/6792 -->
 		<ItemGroup>
-			<FilteredAnalyzer Include="@(Analyzer->Distinct())" />
+			<FilteredAnalyzer Include="@(Analyzer-&gt;Distinct())" />
 			<Analyzer Remove="@(Analyzer)" />
 			<Analyzer Include="@(FilteredAnalyzer)" />
 		</ItemGroup>

--- a/samples/Sql.ConsoleApp/Sql.ConsoleApp.csproj
+++ b/samples/Sql.ConsoleApp/Sql.ConsoleApp.csproj
@@ -2,7 +2,7 @@
 
 	<PropertyGroup>
 		<OutputType>Exe</OutputType>
-		<TargetFramework>net9.0</TargetFramework>
+		<TargetFramework>net10.0</TargetFramework>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
 	</PropertyGroup>

--- a/samples/Sql.ConsoleApp/Sql.ConsoleApp.csproj
+++ b/samples/Sql.ConsoleApp/Sql.ConsoleApp.csproj
@@ -2,7 +2,7 @@
 
 	<PropertyGroup>
 		<OutputType>Exe</OutputType>
-		<TargetFramework>net8.0</TargetFramework>
+		<TargetFramework>net9.0</TargetFramework>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
 	</PropertyGroup>

--- a/samples/Sql.ConsoleApp/Sql.ConsoleApp.csproj
+++ b/samples/Sql.ConsoleApp/Sql.ConsoleApp.csproj
@@ -9,8 +9,8 @@
 
 	<ItemGroup>
 		<PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.6" />
-		<PackageReference Include="Serilog.Extensions.Hosting" Version="8.0.0" />
-		<PackageReference Include="Serilog.Sinks.Console" Version="5.0.1" />
+		<PackageReference Include="Serilog.Extensions.Hosting" Version="9.0.0" />
+		<PackageReference Include="Serilog.Sinks.Console" Version="6.0.0" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/samples/Sql.ConsoleApp/Sql.ConsoleApp.csproj
+++ b/samples/Sql.ConsoleApp/Sql.ConsoleApp.csproj
@@ -8,7 +8,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.0" />
+		<PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.6" />
 		<PackageReference Include="Serilog.Extensions.Hosting" Version="8.0.0" />
 		<PackageReference Include="Serilog.Sinks.Console" Version="5.0.1" />
 	</ItemGroup>

--- a/samples/Sql.ConsoleApp/Sql.ConsoleApp.csproj
+++ b/samples/Sql.ConsoleApp/Sql.ConsoleApp.csproj
@@ -8,9 +8,9 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.6" />
-		<PackageReference Include="Serilog.Extensions.Hosting" Version="9.0.0" />
-		<PackageReference Include="Serilog.Sinks.Console" Version="6.0.0" />
+		<PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.10" />
+		<PackageReference Include="Serilog.Extensions.Hosting" Version="10.0.0" />
+		<PackageReference Include="Serilog.Sinks.Console" Version="6.1.1" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/ARSoftware.Contpaqi.Comercial.Sdk.Abstractions/ARSoftware.Contpaqi.Comercial.Sdk.Abstractions.csproj
+++ b/src/ARSoftware.Contpaqi.Comercial.Sdk.Abstractions/ARSoftware.Contpaqi.Comercial.Sdk.Abstractions.csproj
@@ -3,10 +3,10 @@
 	<PropertyGroup>
 		<TargetFramework>net9.0</TargetFramework>
 		<Nullable>enable</Nullable>
-		<Version>6.2.1</Version>
+		<Version>6.3.0</Version>
 		<Authors>AR Software</Authors>
 		<Description>Esta libreria contiene las interfaces usadas por los poryectos de SDK y SQL.</Description>
-		<Copyright>Copyright © AR Software 2024</Copyright>
+		<Copyright>Copyright © AR Software 2025</Copyright>
 		<RepositoryUrl>https://github.com/AndresRamos/ARSoftware.Contpaqi.Comercial</RepositoryUrl>
 		<PackageProjectUrl>https://github.com/AndresRamos/ARSoftware.Contpaqi.Comercial</PackageProjectUrl>
 		<RepositoryType>git</RepositoryType>

--- a/src/ARSoftware.Contpaqi.Comercial.Sdk.Abstractions/ARSoftware.Contpaqi.Comercial.Sdk.Abstractions.csproj
+++ b/src/ARSoftware.Contpaqi.Comercial.Sdk.Abstractions/ARSoftware.Contpaqi.Comercial.Sdk.Abstractions.csproj
@@ -35,8 +35,8 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Ardalis.SmartEnum" Version="8.0.0" />
-		<PackageReference Include="Ardalis.SmartEnum.SystemTextJson" Version="8.0.0" />
+		<PackageReference Include="Ardalis.SmartEnum" Version="8.2.0" />
+		<PackageReference Include="Ardalis.SmartEnum.SystemTextJson" Version="8.1.0" />
 		<PackageReference Include="AutoMapper" Version="13.0.1" />
 	</ItemGroup>
 

--- a/src/ARSoftware.Contpaqi.Comercial.Sdk.Abstractions/ARSoftware.Contpaqi.Comercial.Sdk.Abstractions.csproj
+++ b/src/ARSoftware.Contpaqi.Comercial.Sdk.Abstractions/ARSoftware.Contpaqi.Comercial.Sdk.Abstractions.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFramework>net9.0</TargetFramework>
+		<TargetFramework>net10.0</TargetFramework>
 		<Nullable>enable</Nullable>
 		<Version>6.3.0</Version>
 		<Authors>AR Software</Authors>

--- a/src/ARSoftware.Contpaqi.Comercial.Sdk.Abstractions/ARSoftware.Contpaqi.Comercial.Sdk.Abstractions.csproj
+++ b/src/ARSoftware.Contpaqi.Comercial.Sdk.Abstractions/ARSoftware.Contpaqi.Comercial.Sdk.Abstractions.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFramework>net8.0</TargetFramework>
+		<TargetFramework>net9.0</TargetFramework>
 		<Nullable>enable</Nullable>
 		<Version>6.2.1</Version>
 		<Authors>AR Software</Authors>

--- a/src/ARSoftware.Contpaqi.Comercial.Sdk.Abstractions/ARSoftware.Contpaqi.Comercial.Sdk.Abstractions.csproj
+++ b/src/ARSoftware.Contpaqi.Comercial.Sdk.Abstractions/ARSoftware.Contpaqi.Comercial.Sdk.Abstractions.csproj
@@ -37,7 +37,7 @@
 	<ItemGroup>
 		<PackageReference Include="Ardalis.SmartEnum" Version="8.2.0" />
 		<PackageReference Include="Ardalis.SmartEnum.SystemTextJson" Version="8.1.0" />
-		<PackageReference Include="AutoMapper" Version="13.0.1" />
+		<PackageReference Include="AutoMapper" Version="14.0.0" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/ARSoftware.Contpaqi.Comercial.Sdk.Abstractions/ARSoftware.Contpaqi.Comercial.Sdk.Abstractions.csproj
+++ b/src/ARSoftware.Contpaqi.Comercial.Sdk.Abstractions/ARSoftware.Contpaqi.Comercial.Sdk.Abstractions.csproj
@@ -6,7 +6,7 @@
 		<Version>6.3.0</Version>
 		<Authors>AR Software</Authors>
 		<Description>Esta libreria contiene las interfaces usadas por los poryectos de SDK y SQL.</Description>
-		<Copyright>Copyright © AR Software 2025</Copyright>
+		<Copyright>Copyright © AR Software 2026</Copyright>
 		<RepositoryUrl>https://github.com/AndresRamos/ARSoftware.Contpaqi.Comercial</RepositoryUrl>
 		<PackageProjectUrl>https://github.com/AndresRamos/ARSoftware.Contpaqi.Comercial</PackageProjectUrl>
 		<RepositoryType>git</RepositoryType>

--- a/src/ARSoftware.Contpaqi.Comercial.Sdk.Extras/ARSoftware.Contpaqi.Comercial.Sdk.Extras.csproj
+++ b/src/ARSoftware.Contpaqi.Comercial.Sdk.Extras/ARSoftware.Contpaqi.Comercial.Sdk.Extras.csproj
@@ -6,7 +6,7 @@
 		<Version>6.3.0</Version>
 		<Authors>AR Software</Authors>
 		<Description>Este proyecto extiende el proyecto ARSoftware.Contpaqi.Comercial.Sdk y dispone de varios repositorios y servicios que implementan las diferentes funcionalidades del SDK.</Description>
-		<Copyright>Copyright © AR Software 2025</Copyright>
+		<Copyright>Copyright © AR Software 2026</Copyright>
 		<RepositoryUrl>https://github.com/AndresRamos/ARSoftware.Contpaqi.Comercial</RepositoryUrl>
 		<PackageProjectUrl>https://github.com/AndresRamos/ARSoftware.Contpaqi.Comercial</PackageProjectUrl>
 		<RepositoryType>git</RepositoryType>

--- a/src/ARSoftware.Contpaqi.Comercial.Sdk.Extras/ARSoftware.Contpaqi.Comercial.Sdk.Extras.csproj
+++ b/src/ARSoftware.Contpaqi.Comercial.Sdk.Extras/ARSoftware.Contpaqi.Comercial.Sdk.Extras.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFramework>net8.0-windows</TargetFramework>
+		<TargetFramework>net9.0-windows</TargetFramework>
 		<Nullable>enable</Nullable>
 		<Version>6.2.1</Version>
 		<Authors>AR Software</Authors>

--- a/src/ARSoftware.Contpaqi.Comercial.Sdk.Extras/ARSoftware.Contpaqi.Comercial.Sdk.Extras.csproj
+++ b/src/ARSoftware.Contpaqi.Comercial.Sdk.Extras/ARSoftware.Contpaqi.Comercial.Sdk.Extras.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFramework>net9.0-windows</TargetFramework>
+		<TargetFramework>net10.0-windows</TargetFramework>
 		<Nullable>enable</Nullable>
 		<Version>6.3.0</Version>
 		<Authors>AR Software</Authors>

--- a/src/ARSoftware.Contpaqi.Comercial.Sdk.Extras/ARSoftware.Contpaqi.Comercial.Sdk.Extras.csproj
+++ b/src/ARSoftware.Contpaqi.Comercial.Sdk.Extras/ARSoftware.Contpaqi.Comercial.Sdk.Extras.csproj
@@ -3,10 +3,10 @@
 	<PropertyGroup>
 		<TargetFramework>net9.0-windows</TargetFramework>
 		<Nullable>enable</Nullable>
-		<Version>6.2.1</Version>
+		<Version>6.3.0</Version>
 		<Authors>AR Software</Authors>
 		<Description>Este proyecto extiende el proyecto ARSoftware.Contpaqi.Comercial.Sdk y dispone de varios repositorios y servicios que implementan las diferentes funcionalidades del SDK.</Description>
-		<Copyright>Copyright © AR Software 2024</Copyright>
+		<Copyright>Copyright © AR Software 2025</Copyright>
 		<RepositoryUrl>https://github.com/AndresRamos/ARSoftware.Contpaqi.Comercial</RepositoryUrl>
 		<PackageProjectUrl>https://github.com/AndresRamos/ARSoftware.Contpaqi.Comercial</PackageProjectUrl>
 		<RepositoryType>git</RepositoryType>

--- a/src/ARSoftware.Contpaqi.Comercial.Sdk/ARSoftware.Contpaqi.Comercial.Sdk.csproj
+++ b/src/ARSoftware.Contpaqi.Comercial.Sdk/ARSoftware.Contpaqi.Comercial.Sdk.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFramework>net8.0</TargetFramework>
+		<TargetFramework>net9.0</TargetFramework>
 		<Nullable>enable</Nullable>
 		<Version>6.2.1</Version>
 		<Authors>AR Software</Authors>

--- a/src/ARSoftware.Contpaqi.Comercial.Sdk/ARSoftware.Contpaqi.Comercial.Sdk.csproj
+++ b/src/ARSoftware.Contpaqi.Comercial.Sdk/ARSoftware.Contpaqi.Comercial.Sdk.csproj
@@ -3,10 +3,10 @@
 	<PropertyGroup>
 		<TargetFramework>net9.0</TargetFramework>
 		<Nullable>enable</Nullable>
-		<Version>6.2.1</Version>
+		<Version>6.3.0</Version>
 		<Authors>AR Software</Authors>
 		<Description>Este proyecto tiene declaradas todas las funciones y clases utilizadas por el SDK de CONTPAQi Comercial, CONTPAQi Adminpaq, y CONTPAQi Factura Electronica.</Description>
-		<Copyright>Copyright © AR Software 2024</Copyright>
+		<Copyright>Copyright © AR Software 2025</Copyright>
 		<RepositoryUrl>https://github.com/AndresRamos/ARSoftware.Contpaqi.Comercial</RepositoryUrl>
 		<PackageProjectUrl>https://github.com/AndresRamos/ARSoftware.Contpaqi.Comercial</PackageProjectUrl>
 		<RepositoryType>git</RepositoryType>

--- a/src/ARSoftware.Contpaqi.Comercial.Sdk/ARSoftware.Contpaqi.Comercial.Sdk.csproj
+++ b/src/ARSoftware.Contpaqi.Comercial.Sdk/ARSoftware.Contpaqi.Comercial.Sdk.csproj
@@ -6,7 +6,7 @@
 		<Version>6.3.0</Version>
 		<Authors>AR Software</Authors>
 		<Description>Este proyecto tiene declaradas todas las funciones y clases utilizadas por el SDK de CONTPAQi Comercial, CONTPAQi Adminpaq, y CONTPAQi Factura Electronica.</Description>
-		<Copyright>Copyright © AR Software 2025</Copyright>
+		<Copyright>Copyright © AR Software 2026</Copyright>
 		<RepositoryUrl>https://github.com/AndresRamos/ARSoftware.Contpaqi.Comercial</RepositoryUrl>
 		<PackageProjectUrl>https://github.com/AndresRamos/ARSoftware.Contpaqi.Comercial</PackageProjectUrl>
 		<RepositoryType>git</RepositoryType>

--- a/src/ARSoftware.Contpaqi.Comercial.Sdk/ARSoftware.Contpaqi.Comercial.Sdk.csproj
+++ b/src/ARSoftware.Contpaqi.Comercial.Sdk/ARSoftware.Contpaqi.Comercial.Sdk.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFramework>net9.0</TargetFramework>
+		<TargetFramework>net10.0</TargetFramework>
 		<Nullable>enable</Nullable>
 		<Version>6.3.0</Version>
 		<Authors>AR Software</Authors>

--- a/src/ARSoftware.Contpaqi.Comercial.Sql.Models/ARSoftware.Contpaqi.Comercial.Sql.Models.csproj
+++ b/src/ARSoftware.Contpaqi.Comercial.Sql.Models/ARSoftware.Contpaqi.Comercial.Sql.Models.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFramework>net9.0</TargetFramework>
+		<TargetFramework>net10.0</TargetFramework>
 		<Nullable>enable</Nullable>
 		<Version>6.3.0</Version>
 		<Authors>AR Software</Authors>

--- a/src/ARSoftware.Contpaqi.Comercial.Sql.Models/ARSoftware.Contpaqi.Comercial.Sql.Models.csproj
+++ b/src/ARSoftware.Contpaqi.Comercial.Sql.Models/ARSoftware.Contpaqi.Comercial.Sql.Models.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFramework>net8.0</TargetFramework>
+		<TargetFramework>net9.0</TargetFramework>
 		<Nullable>enable</Nullable>
 		<Version>6.2.1</Version>
 		<Authors>AR Software</Authors>

--- a/src/ARSoftware.Contpaqi.Comercial.Sql.Models/ARSoftware.Contpaqi.Comercial.Sql.Models.csproj
+++ b/src/ARSoftware.Contpaqi.Comercial.Sql.Models/ARSoftware.Contpaqi.Comercial.Sql.Models.csproj
@@ -6,7 +6,7 @@
 		<Version>6.3.0</Version>
 		<Authors>AR Software</Authors>
 		<Description>Modelo de las bases de datos de CONTPAQi Comercial v11.2.1</Description>
-		<Copyright>Copyright © AR Software 2025</Copyright>
+		<Copyright>Copyright © AR Software 2026</Copyright>
 		<RepositoryUrl>https://github.com/AndresRamos/ARSoftware.Contpaqi.Comercial</RepositoryUrl>
 		<PackageProjectUrl>https://github.com/AndresRamos/ARSoftware.Contpaqi.Comercial</PackageProjectUrl>
 		<RepositoryType>git</RepositoryType>

--- a/src/ARSoftware.Contpaqi.Comercial.Sql.Models/ARSoftware.Contpaqi.Comercial.Sql.Models.csproj
+++ b/src/ARSoftware.Contpaqi.Comercial.Sql.Models/ARSoftware.Contpaqi.Comercial.Sql.Models.csproj
@@ -3,10 +3,10 @@
 	<PropertyGroup>
 		<TargetFramework>net9.0</TargetFramework>
 		<Nullable>enable</Nullable>
-		<Version>6.2.1</Version>
+		<Version>6.3.0</Version>
 		<Authors>AR Software</Authors>
-		<Description>Modelo de las bases de datos de CONTPAQi Comercial v9.2.1</Description>
-		<Copyright>Copyright © AR Software 2024</Copyright>
+		<Description>Modelo de las bases de datos de CONTPAQi Comercial v11.2.1</Description>
+		<Copyright>Copyright © AR Software 2025</Copyright>
 		<RepositoryUrl>https://github.com/AndresRamos/ARSoftware.Contpaqi.Comercial</RepositoryUrl>
 		<PackageProjectUrl>https://github.com/AndresRamos/ARSoftware.Contpaqi.Comercial</PackageProjectUrl>
 		<RepositoryType>git</RepositoryType>

--- a/src/ARSoftware.Contpaqi.Comercial.Sql.Models/Empresa/admAperturas.cs
+++ b/src/ARSoftware.Contpaqi.Comercial.Sql.Models/Empresa/admAperturas.cs
@@ -1,0 +1,33 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace ARSoftware.Contpaqi.Comercial.Sql.Models.Empresa;
+
+public partial class admAperturas
+{
+    public int CIDAPERTURA { get; set; }
+
+    public int CIDCAJA { get; set; }
+
+    public int CIDAGENTE { get; set; }
+
+    public string? CUSUARIO { get; set; }
+
+    public string CTERMINAL { get; set; } = null!;
+
+    public int CESTADO { get; set; }
+
+    public DateTime CFECHAAPERTURA { get; set; }
+
+    public string CHORAAPERTURA { get; set; } = null!;
+
+    public DateTime CFECHACORTE { get; set; }
+
+    public string CHORACORTE { get; set; } = null!;
+
+    public DateTime CFECHAFACTURA { get; set; }
+
+    public int CIDFACTURA { get; set; }
+
+    public string CTIMESTAMP { get; set; } = null!;
+}

--- a/src/ARSoftware.Contpaqi.Comercial.Sql.Models/Empresa/admAsocBuzones.cs
+++ b/src/ARSoftware.Contpaqi.Comercial.Sql.Models/Empresa/admAsocBuzones.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace ARSoftware.Contpaqi.Comercial.Sql.Models.Empresa;
+
+public partial class admAsocBuzones
+{
+    public int CTIPOCATALOGO { get; set; }
+
+    public int CIDCATALOGO { get; set; }
+
+    public string CINBOXID { get; set; } = null!;
+
+    public string? CPRIVATEPEMKEY { get; set; }
+
+    public string? CPUBLICPEMKEY { get; set; }
+
+    public string CPASSWORD { get; set; } = null!;
+}

--- a/src/ARSoftware.Contpaqi.Comercial.Sql.Models/Empresa/admAsocCargosAbonosImp.cs
+++ b/src/ARSoftware.Contpaqi.Comercial.Sql.Models/Empresa/admAsocCargosAbonosImp.cs
@@ -30,4 +30,10 @@ public partial class admAsocCargosAbonosImp
     public double CPROPORC01 { get; set; }
 
     public string CMETODOPAG { get; set; } = null!;
+
+    public string COBJIMPU01 { get; set; } = null!;
+
+    public int CCOMPUTA01 { get; set; }
+
+    public string CNOMIMPLOC { get; set; } = null!;
 }

--- a/src/ARSoftware.Contpaqi.Comercial.Sql.Models/Empresa/admAsocLigasPagos.cs
+++ b/src/ARSoftware.Contpaqi.Comercial.Sql.Models/Empresa/admAsocLigasPagos.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace ARSoftware.Contpaqi.Comercial.Sql.Models.Empresa;
+
+public partial class admAsocLigasPagos
+{
+    public int CIDLIGA { get; set; }
+
+    public int CIDDOCTO { get; set; }
+
+    public double CIMPORTEPAGO { get; set; }
+}

--- a/src/ARSoftware.Contpaqi.Comercial.Sql.Models/Empresa/admBuzones.cs
+++ b/src/ARSoftware.Contpaqi.Comercial.Sql.Models/Empresa/admBuzones.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace ARSoftware.Contpaqi.Comercial.Sql.Models.Empresa;
+
+public partial class admBuzones
+{
+    public string CINBOXID { get; set; } = null!;
+
+    public string CALIAS { get; set; } = null!;
+
+    public string CSUBSCRIPTIONID { get; set; } = null!;
+
+    public string? CSUBSCRIPTIONKEY { get; set; }
+
+    public string CENCRYPTIONKEYID { get; set; } = null!;
+
+    public DateTime CCREATEDAT { get; set; }
+
+    public DateTime CUPDATEDAT { get; set; }
+
+    public int CTIPO { get; set; }
+
+    public int CESTADO { get; set; }
+}

--- a/src/ARSoftware.Contpaqi.Comercial.Sql.Models/Empresa/admCajas.cs
+++ b/src/ARSoftware.Contpaqi.Comercial.Sql.Models/Empresa/admCajas.cs
@@ -1,0 +1,59 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace ARSoftware.Contpaqi.Comercial.Sql.Models.Empresa;
+
+public partial class admCajas
+{
+    public int CIDCAJA { get; set; }
+
+    public string CCODIGOCAJA { get; set; } = null!;
+
+    public string CNOMBRECAJA { get; set; } = null!;
+
+    public int CESTATUS { get; set; }
+
+    public DateTime CFECHAALTA { get; set; }
+
+    public DateTime CFECHABAJA { get; set; }
+
+    public int CIDVALORCLASIFICACION1 { get; set; }
+
+    public double CFOLIONOTA { get; set; }
+
+    public string CSERIENOTA { get; set; } = null!;
+
+    public double CFOLIODEVN { get; set; }
+
+    public string CSERIEDEVN { get; set; } = null!;
+
+    public int CIDALMACEN { get; set; }
+
+    public int CIDUSUARIO { get; set; }
+
+    public int CIDCLIENTE { get; set; }
+
+    public string CTEXTOEXTRA1 { get; set; } = null!;
+
+    public string CTEXTOEXTRA2 { get; set; } = null!;
+
+    public string CTEXTOEXTRA3 { get; set; } = null!;
+
+    public DateTime CFECHAEXTRA { get; set; }
+
+    public double CIMPORTEEXTRA1 { get; set; }
+
+    public double CIMPORTEEXTRA2 { get; set; }
+
+    public double CIMPORTEEXTRA3 { get; set; }
+
+    public double CIMPORTEEXTRA4 { get; set; }
+
+    public string CTIMESTAMP { get; set; } = null!;
+
+    public string cReporteApertura { get; set; } = null!;
+
+    public string cReporteCorte { get; set; } = null!;
+
+    public string cReporteNota { get; set; } = null!;
+}

--- a/src/ARSoftware.Contpaqi.Comercial.Sql.Models/Empresa/admClientes.cs
+++ b/src/ARSoftware.Contpaqi.Comercial.Sql.Models/Empresa/admClientes.cs
@@ -254,4 +254,6 @@ public partial class admClientes
     public string CREGIMFISC { get; set; } = null!;
 
     public string CWHATSAPP { get; set; } = null!;
+
+    public string CCODIGOALTERNO { get; set; } = null!;
 }

--- a/src/ARSoftware.Contpaqi.Comercial.Sql.Models/Empresa/admClientes.cs
+++ b/src/ARSoftware.Contpaqi.Comercial.Sql.Models/Empresa/admClientes.cs
@@ -252,4 +252,6 @@ public partial class admClientes
     public string CUSOCFDI { get; set; } = null!;
 
     public string CREGIMFISC { get; set; } = null!;
+
+    public string CWHATSAPP { get; set; } = null!;
 }

--- a/src/ARSoftware.Contpaqi.Comercial.Sql.Models/Empresa/admConceptos.cs
+++ b/src/ARSoftware.Contpaqi.Comercial.Sql.Models/Empresa/admConceptos.cs
@@ -400,4 +400,8 @@ public partial class admConceptos
     public int CIDPRSEG08 { get; set; }
 
     public int CUSAOBJIMP { get; set; }
+
+    public int CCONFIEPS { get; set; }
+
+    public int CHABILITARPORTALFACT { get; set; }
 }

--- a/src/ARSoftware.Contpaqi.Comercial.Sql.Models/Empresa/admConceptosBack.cs
+++ b/src/ARSoftware.Contpaqi.Comercial.Sql.Models/Empresa/admConceptosBack.cs
@@ -392,4 +392,6 @@ public partial class admConceptosBack
     public string CCLAVESAT { get; set; } = null!;
 
     public int CUSAOBJIMP { get; set; }
+
+    public int CCONFIEPS { get; set; }
 }

--- a/src/ARSoftware.Contpaqi.Comercial.Sql.Models/Empresa/admConfigProveedoresNube.cs
+++ b/src/ARSoftware.Contpaqi.Comercial.Sql.Models/Empresa/admConfigProveedoresNube.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace ARSoftware.Contpaqi.Comercial.Sql.Models.Empresa;
+
+public partial class admConfigProveedoresNube
+{
+    public int CIDPROVEEDORSERVICIO { get; set; }
+
+    public int CACTIVO { get; set; }
+
+    public int CTIENEVIGENCIA { get; set; }
+
+    public int CDIASVIGENCIA { get; set; }
+}

--- a/src/ARSoftware.Contpaqi.Comercial.Sql.Models/Empresa/admDocumentos.cs
+++ b/src/ARSoftware.Contpaqi.Comercial.Sql.Models/Empresa/admDocumentos.cs
@@ -190,4 +190,12 @@ public partial class admDocumentos
     public string? CDATOSADICIONALES { get; set; }
 
     public int CIDAPERTURA { get; set; }
+
+    public int CDOCTOENV { get; set; }
+
+    public string CCODIGOFACTURACION { get; set; } = null!;
+
+    public DateTime CFECHAFACTURACION { get; set; }
+
+    public string CTICKETID { get; set; } = null!;
 }

--- a/src/ARSoftware.Contpaqi.Comercial.Sql.Models/Empresa/admDocumentos.cs
+++ b/src/ARSoftware.Contpaqi.Comercial.Sql.Models/Empresa/admDocumentos.cs
@@ -186,4 +186,8 @@ public partial class admDocumentos
     public int CIDCOPIADE { get; set; }
 
     public string CVERESQUE { get; set; } = null!;
+
+    public string? CDATOSADICIONALES { get; set; }
+
+    public int CIDAPERTURA { get; set; }
 }

--- a/src/ARSoftware.Contpaqi.Comercial.Sql.Models/Empresa/admDocumentosOrigen.cs
+++ b/src/ARSoftware.Contpaqi.Comercial.Sql.Models/Empresa/admDocumentosOrigen.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace ARSoftware.Contpaqi.Comercial.Sql.Models.Empresa;
+
+public partial class admDocumentosOrigen
+{
+    public int CIDDOCUMENTO { get; set; }
+
+    public string CSERIE { get; set; } = null!;
+
+    public double CFOLIO { get; set; }
+
+    public DateTime CFECHA { get; set; }
+}

--- a/src/ARSoftware.Contpaqi.Comercial.Sql.Models/Empresa/admFormasPago.cs
+++ b/src/ARSoftware.Contpaqi.Comercial.Sql.Models/Empresa/admFormasPago.cs
@@ -1,0 +1,41 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace ARSoftware.Contpaqi.Comercial.Sql.Models.Empresa;
+
+public partial class admFormasPago
+{
+    public int CIDFORMAPAGO { get; set; }
+
+    public string CCODIGOFORMAPAGO { get; set; } = null!;
+
+    public string CNOMBREFORMAPAGO { get; set; } = null!;
+
+    public int CESTATUS { get; set; }
+
+    public DateTime CFECHAALTA { get; set; }
+
+    public DateTime CFECHABAJA { get; set; }
+
+    public string CCLAVESAT { get; set; } = null!;
+
+    public int CIDMONEDA { get; set; }
+
+    public string CTEXTOEXTRA1 { get; set; } = null!;
+
+    public string CTEXTOEXTRA2 { get; set; } = null!;
+
+    public string CTEXTOEXTRA3 { get; set; } = null!;
+
+    public DateTime CFECHAEXTRA { get; set; }
+
+    public double CIMPORTEEXTRA1 { get; set; }
+
+    public double CIMPORTEEXTRA2 { get; set; }
+
+    public double CIMPORTEEXTRA3 { get; set; }
+
+    public double CIMPORTEEXTRA4 { get; set; }
+
+    public string CTIMESTAMP { get; set; } = null!;
+}

--- a/src/ARSoftware.Contpaqi.Comercial.Sql.Models/Empresa/admLigasPago.cs
+++ b/src/ARSoftware.Contpaqi.Comercial.Sql.Models/Empresa/admLigasPago.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace ARSoftware.Contpaqi.Comercial.Sql.Models.Empresa;
+
+public partial class admLigasPago
+{
+    public int CIDLIGA { get; set; }
+
+    public int CIDCLIENTEPROVEEDOR { get; set; }
+
+    public int CIDMONEDA { get; set; }
+
+    public int CIDPROVEEDORSERVICIO { get; set; }
+
+    public DateTime CFECHAINIVIG { get; set; }
+
+    public DateTime CFECHAFINVIG { get; set; }
+
+    public DateTime CFECHAPAGO { get; set; }
+
+    public int CESTADO { get; set; }
+
+    public int CTIPOPAGO { get; set; }
+
+    public string? CLIGA { get; set; }
+
+    public string CGUIDEXTERNALREF { get; set; } = null!;
+
+    public string CGUIDLIGA { get; set; } = null!;
+
+    public int CIDDOCTOABONO { get; set; }
+
+    public double CTOTAL { get; set; }
+}

--- a/src/ARSoftware.Contpaqi.Comercial.Sql.Models/Empresa/admMensajes.cs
+++ b/src/ARSoftware.Contpaqi.Comercial.Sql.Models/Empresa/admMensajes.cs
@@ -1,0 +1,41 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace ARSoftware.Contpaqi.Comercial.Sql.Models.Empresa;
+
+public partial class admMensajes
+{
+    public string CMESSAGEID { get; set; } = null!;
+
+    public string CINBOXID { get; set; } = null!;
+
+    public string CALIAS { get; set; } = null!;
+
+    public string? CBODY { get; set; }
+
+    public string CCONTENTTYPE { get; set; } = null!;
+
+    public string CCONTENTENCODING { get; set; } = null!;
+
+    public DateTime CDUEDATE { get; set; }
+
+    public string CPRIORITY { get; set; } = null!;
+
+    public string? CTAGS { get; set; }
+
+    public DateTime CQUEUEDAT { get; set; }
+
+    public int CSTATUS { get; set; }
+
+    public string CUSUARIO { get; set; } = null!;
+
+    public string CPROCESO { get; set; } = null!;
+
+    public string CDATOS { get; set; } = null!;
+
+    public DateTime CFECHA { get; set; }
+
+    public string CHORA { get; set; } = null!;
+
+    public string CERROR { get; set; } = null!;
+}

--- a/src/ARSoftware.Contpaqi.Comercial.Sql.Models/Empresa/admMovimientos.cs
+++ b/src/ARSoftware.Contpaqi.Comercial.Sql.Models/Empresa/admMovimientos.cs
@@ -140,4 +140,12 @@ public partial class admMovimientos
     public int CNUMEROCONSOLIDACIONES { get; set; }
 
     public string COBJIMPU01 { get; set; } = null!;
+
+    public int CCONFIMP1 { get; set; }
+
+    public int CCONFIMP2 { get; set; }
+
+    public int CCONFIMP3 { get; set; }
+
+    public int CCONFIMP4 { get; set; }
 }

--- a/src/ARSoftware.Contpaqi.Comercial.Sql.Models/Empresa/admMovimientosContables.cs
+++ b/src/ARSoftware.Contpaqi.Comercial.Sql.Models/Empresa/admMovimientosContables.cs
@@ -44,4 +44,12 @@ public partial class admMovimientosContables
     public int CIMPMONDOC { get; set; }
 
     public int CCOMPLEMEN { get; set; }
+
+    public int CBASECONDICION { get; set; }
+
+    public double CVALORMINIMO { get; set; }
+
+    public double CVALORMAXIMO { get; set; }
+
+    public int CORIGENIMPORTES { get; set; }
 }

--- a/src/ARSoftware.Contpaqi.Comercial.Sql.Models/Empresa/admPagoNotas.cs
+++ b/src/ARSoftware.Contpaqi.Comercial.Sql.Models/Empresa/admPagoNotas.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace ARSoftware.Contpaqi.Comercial.Sql.Models.Empresa;
+
+public partial class admPagoNotas
+{
+    public int CIDPAGO { get; set; }
+
+    public int CIDDOCUMENTO { get; set; }
+
+    public int CIDFORMAPAGO { get; set; }
+
+    public int CTIPO { get; set; }
+
+    public double CIMPORTE { get; set; }
+
+    public int CIDMONEDA { get; set; }
+
+    public double CTIPOCAMBIO { get; set; }
+
+    public string CREFERENCIA { get; set; } = null!;
+
+    public string CTIMESTAMP { get; set; } = null!;
+}

--- a/src/ARSoftware.Contpaqi.Comercial.Sql.Models/Empresa/admParametros.cs
+++ b/src/ARSoftware.Contpaqi.Comercial.Sql.Models/Empresa/admParametros.cs
@@ -432,4 +432,16 @@ public partial class admParametros
     public int CUSACORREOOAUTH { get; set; }
 
     public string CPROVEEDOROAUTH { get; set; } = null!;
+
+    public int CUSABUZON { get; set; }
+
+    public string CINBOXID { get; set; } = null!;
+
+    public int CUSAPORTALFACT { get; set; }
+
+    public int CPORTALTIPOFACT { get; set; }
+
+    public int CPORTALDIASFACT { get; set; }
+
+    public string CIDPORTALFACT { get; set; } = null!;
 }

--- a/src/ARSoftware.Contpaqi.Comercial.Sql.Models/Empresa/admParametros.cs
+++ b/src/ARSoftware.Contpaqi.Comercial.Sql.Models/Empresa/admParametros.cs
@@ -428,4 +428,8 @@ public partial class admParametros
     public string? CURLWSTORE { get; set; }
 
     public string CLEYENDON { get; set; } = null!;
+
+    public int CUSACORREOOAUTH { get; set; }
+
+    public string CPROVEEDOROAUTH { get; set; } = null!;
 }

--- a/src/ARSoftware.Contpaqi.Comercial.Sql.Models/Empresa/admProductos.cs
+++ b/src/ARSoftware.Contpaqi.Comercial.Sql.Models/Empresa/admProductos.cs
@@ -218,4 +218,12 @@ public partial class admProductos
     public string CCLAVESAT { get; set; } = null!;
 
     public double CCANTIDADFISCAL { get; set; }
+
+    public int CUNIDADDIMENSION { get; set; }
+
+    public double CALTO { get; set; }
+
+    public double CLARGO { get; set; }
+
+    public double CANCHO { get; set; }
 }

--- a/src/ARSoftware.Contpaqi.Comercial.Sql.Models/Empresa/admSegmentosImpuestos.cs
+++ b/src/ARSoftware.Contpaqi.Comercial.Sql.Models/Empresa/admSegmentosImpuestos.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace ARSoftware.Contpaqi.Comercial.Sql.Models.Empresa;
+
+public partial class admSegmentosImpuestos
+{
+    public int CIDSEGMENTO { get; set; }
+
+    public int CTIPO { get; set; }
+
+    public int CCATALOGO { get; set; }
+
+    public double CTASAMIN { get; set; }
+
+    public double CTASAMAX { get; set; }
+
+    public string CSEGMENTO1 { get; set; } = null!;
+
+    public string CSEGMENTO2 { get; set; } = null!;
+
+    public string CSEGMENTO3 { get; set; } = null!;
+
+    public string CTIMESTAMP { get; set; } = null!;
+}

--- a/src/ARSoftware.Contpaqi.Comercial.Sql.Models/Generales/ProveedoresNube.cs
+++ b/src/ARSoftware.Contpaqi.Comercial.Sql.Models/Generales/ProveedoresNube.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace ARSoftware.Contpaqi.Comercial.Sql.Models.Generales;
+
+public partial class ProveedoresNube
+{
+    public int CIDPROVEEDORSERVICIO { get; set; }
+
+    public string CNOMBREPROVEEDOR { get; set; } = null!;
+
+    public int CTIPOPROVEEDOR { get; set; }
+
+    public int CACTIVO { get; set; }
+
+    public string CURLBASE { get; set; } = null!;
+}

--- a/src/ARSoftware.Contpaqi.Comercial.Sql/ARSoftware.Contpaqi.Comercial.Sql.csproj
+++ b/src/ARSoftware.Contpaqi.Comercial.Sql/ARSoftware.Contpaqi.Comercial.Sql.csproj
@@ -3,10 +3,10 @@
 	<PropertyGroup>
 		<TargetFramework>net9.0</TargetFramework>
 		<Nullable>enable</Nullable>
-		<Version>6.2.1</Version>
+		<Version>6.3.0</Version>
 		<Authors>AR Software</Authors>
-		<Description>Entity Framework DbContexts para hacer query las bases de datos de CONTPAQi Comercial v9.2.1</Description>
-		<Copyright>Copyright © AR Software 2024</Copyright>
+		<Description>Entity Framework DbContexts para hacer query las bases de datos de CONTPAQi Comercial v11.2.1</Description>
+		<Copyright>Copyright © AR Software 2025</Copyright>
 		<RepositoryUrl>https://github.com/AndresRamos/ARSoftware.Contpaqi.Comercial</RepositoryUrl>
 		<PackageProjectUrl>https://github.com/AndresRamos/ARSoftware.Contpaqi.Comercial</PackageProjectUrl>
 		<RepositoryType>git</RepositoryType>

--- a/src/ARSoftware.Contpaqi.Comercial.Sql/ARSoftware.Contpaqi.Comercial.Sql.csproj
+++ b/src/ARSoftware.Contpaqi.Comercial.Sql/ARSoftware.Contpaqi.Comercial.Sql.csproj
@@ -26,8 +26,8 @@
 	</ItemGroup>
 	
 	<ItemGroup>
-		<PackageReference Include="Ardalis.Specification" Version="8.0.0" />
-		<PackageReference Include="Ardalis.Specification.EntityFrameworkCore" Version="8.0.0" />
+		<PackageReference Include="Ardalis.Specification" Version="9.2.0" />
+		<PackageReference Include="Ardalis.Specification.EntityFrameworkCore" Version="9.2.0" />
 		<PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="9.0.6" />
 	</ItemGroup>
 

--- a/src/ARSoftware.Contpaqi.Comercial.Sql/ARSoftware.Contpaqi.Comercial.Sql.csproj
+++ b/src/ARSoftware.Contpaqi.Comercial.Sql/ARSoftware.Contpaqi.Comercial.Sql.csproj
@@ -28,7 +28,7 @@
 	<ItemGroup>
 		<PackageReference Include="Ardalis.Specification" Version="8.0.0" />
 		<PackageReference Include="Ardalis.Specification.EntityFrameworkCore" Version="8.0.0" />
-		<PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.0" />
+		<PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="9.0.6" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/ARSoftware.Contpaqi.Comercial.Sql/ARSoftware.Contpaqi.Comercial.Sql.csproj
+++ b/src/ARSoftware.Contpaqi.Comercial.Sql/ARSoftware.Contpaqi.Comercial.Sql.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFramework>net8.0</TargetFramework>
+		<TargetFramework>net9.0</TargetFramework>
 		<Nullable>enable</Nullable>
 		<Version>6.2.1</Version>
 		<Authors>AR Software</Authors>

--- a/src/ARSoftware.Contpaqi.Comercial.Sql/ARSoftware.Contpaqi.Comercial.Sql.csproj
+++ b/src/ARSoftware.Contpaqi.Comercial.Sql/ARSoftware.Contpaqi.Comercial.Sql.csproj
@@ -26,9 +26,9 @@
 	</ItemGroup>
 	
 	<ItemGroup>
-		<PackageReference Include="Ardalis.Specification" Version="9.2.0" />
-		<PackageReference Include="Ardalis.Specification.EntityFrameworkCore" Version="9.2.0" />
-		<PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="9.0.6" />
+		<PackageReference Include="Ardalis.Specification" Version="9.3.1" />
+		<PackageReference Include="Ardalis.Specification.EntityFrameworkCore" Version="9.3.1" />
+		<PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.0.10" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/ARSoftware.Contpaqi.Comercial.Sql/ARSoftware.Contpaqi.Comercial.Sql.csproj
+++ b/src/ARSoftware.Contpaqi.Comercial.Sql/ARSoftware.Contpaqi.Comercial.Sql.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFramework>net9.0</TargetFramework>
+		<TargetFramework>net10.0</TargetFramework>
 		<Nullable>enable</Nullable>
 		<Version>6.3.0</Version>
 		<Authors>AR Software</Authors>

--- a/src/ARSoftware.Contpaqi.Comercial.Sql/ARSoftware.Contpaqi.Comercial.Sql.csproj
+++ b/src/ARSoftware.Contpaqi.Comercial.Sql/ARSoftware.Contpaqi.Comercial.Sql.csproj
@@ -6,7 +6,7 @@
 		<Version>6.3.0</Version>
 		<Authors>AR Software</Authors>
 		<Description>Entity Framework DbContexts para hacer query las bases de datos de CONTPAQi Comercial v11.2.1</Description>
-		<Copyright>Copyright © AR Software 2025</Copyright>
+		<Copyright>Copyright © AR Software 2026</Copyright>
 		<RepositoryUrl>https://github.com/AndresRamos/ARSoftware.Contpaqi.Comercial</RepositoryUrl>
 		<PackageProjectUrl>https://github.com/AndresRamos/ARSoftware.Contpaqi.Comercial</PackageProjectUrl>
 		<RepositoryType>git</RepositoryType>

--- a/src/ARSoftware.Contpaqi.Comercial.Sql/Contexts/ContpaqiComercialEmpresaDbContext.cs
+++ b/src/ARSoftware.Contpaqi.Comercial.Sql/Contexts/ContpaqiComercialEmpresaDbContext.cs
@@ -26,13 +26,19 @@ public partial class ContpaqiComercialEmpresaDbContext : DbContext
 
     public virtual DbSet<admAsocAcumConceptos> admAsocAcumConceptos { get; set; }
 
+    public virtual DbSet<admAsocBuzones> admAsocBuzones { get; set; }
+
     public virtual DbSet<admAsocCargosAbonos> admAsocCargosAbonos { get; set; }
 
     public virtual DbSet<admAsocCargosAbonosImp> admAsocCargosAbonosImp { get; set; }
 
+    public virtual DbSet<admAsocLigasPagos> admAsocLigasPagos { get; set; }
+
     public virtual DbSet<admBanderas> admBanderas { get; set; }
 
     public virtual DbSet<admBitacoras> admBitacoras { get; set; }
+
+    public virtual DbSet<admBuzones> admBuzones { get; set; }
 
     public virtual DbSet<admCajas> admCajas { get; set; }
 
@@ -54,6 +60,8 @@ public partial class ContpaqiComercialEmpresaDbContext : DbContext
 
     public virtual DbSet<admConceptosBack> admConceptosBack { get; set; }
 
+    public virtual DbSet<admConfigProveedoresNube> admConfigProveedoresNube { get; set; }
+
     public virtual DbSet<admConversionesUnidad> admConversionesUnidad { get; set; }
 
     public virtual DbSet<admCostosHistoricos> admCostosHistoricos { get; set; }
@@ -68,6 +76,8 @@ public partial class ContpaqiComercialEmpresaDbContext : DbContext
 
     public virtual DbSet<admDocumentosModelosBack> admDocumentosModelosBack { get; set; }
 
+    public virtual DbSet<admDocumentosOrigen> admDocumentosOrigen { get; set; }
+
     public virtual DbSet<admDomicilios> admDomicilios { get; set; }
 
     public virtual DbSet<admEjercicios> admEjercicios { get; set; }
@@ -78,7 +88,11 @@ public partial class ContpaqiComercialEmpresaDbContext : DbContext
 
     public virtual DbSet<admFormasPago> admFormasPago { get; set; }
 
+    public virtual DbSet<admLigasPago> admLigasPago { get; set; }
+
     public virtual DbSet<admMaximosMinimos> admMaximosMinimos { get; set; }
+
+    public virtual DbSet<admMensajes> admMensajes { get; set; }
 
     public virtual DbSet<admMonedas> admMonedas { get; set; }
 
@@ -124,6 +138,8 @@ public partial class ContpaqiComercialEmpresaDbContext : DbContext
 
     public virtual DbSet<admSATSegmentos> admSATSegmentos { get; set; }
 
+    public virtual DbSet<admSegmentosImpuestos> admSegmentosImpuestos { get; set; }
+
     public virtual DbSet<admTiposCambio> admTiposCambio { get; set; }
 
     public virtual DbSet<admUnidadesMedidaPeso> admUnidadesMedidaPeso { get; set; }
@@ -159,7 +175,7 @@ public partial class ContpaqiComercialEmpresaDbContext : DbContext
             entity.Property(e => e.CTIMESTAMP)
                 .HasMaxLength(23)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW10018_CTIMESTAMP");
         });
 
         modelBuilder.Entity<admAcumuladosTipos>(entity =>
@@ -169,7 +185,7 @@ public partial class ContpaqiComercialEmpresaDbContext : DbContext
             entity.Property(e => e.CNOMBRE)
                 .HasMaxLength(60)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW10012_CNOMBRE");
         });
 
         modelBuilder.Entity<admAgentes>(entity =>
@@ -203,45 +219,45 @@ public partial class ContpaqiComercialEmpresaDbContext : DbContext
             entity.Property(e => e.CCODIGOAGENTE)
                 .HasMaxLength(30)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW10001_CCODIGOA01");
             entity.Property(e => e.CFECHAALTAAGENTE)
-                .HasDefaultValueSql("('18991230')")
+                .HasDefaultValueSql("('18991230')", "DF_MGW10001_CFECHAAL01")
                 .HasColumnType("datetime");
             entity.Property(e => e.CFECHAEXTRA)
-                .HasDefaultValueSql("('18991230')")
+                .HasDefaultValueSql("('18991230')", "DF_MGW10001_CFECHAEX01")
                 .HasColumnType("datetime");
             entity.Property(e => e.CNOMBREAGENTE)
                 .HasMaxLength(60)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW10001_CNOMBREA01");
             entity.Property(e => e.CSCAGENTE2)
                 .HasMaxLength(50)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW10001_CSCAGENTE2");
             entity.Property(e => e.CSCAGENTE3)
                 .HasMaxLength(50)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW10001_CSCAGENTE3");
             entity.Property(e => e.CSEGCONTAGENTE)
                 .HasMaxLength(50)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW10001_CSEGCONT01");
             entity.Property(e => e.CTEXTOEXTRA1)
                 .HasMaxLength(50)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW10001_CTEXTOEX01");
             entity.Property(e => e.CTEXTOEXTRA2)
                 .HasMaxLength(50)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW10001_CTEXTOEX02");
             entity.Property(e => e.CTEXTOEXTRA3)
                 .HasMaxLength(50)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW10001_CTEXTOEX03");
             entity.Property(e => e.CTIMESTAMP)
                 .HasMaxLength(23)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW10001_CTIMESTAMP");
         });
 
         modelBuilder.Entity<admAlmacenes>(entity =>
@@ -269,45 +285,45 @@ public partial class ContpaqiComercialEmpresaDbContext : DbContext
             entity.Property(e => e.CCODIGOALMACEN)
                 .HasMaxLength(30)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW10003_CCODIGOA01");
             entity.Property(e => e.CFECHAALTAALMACEN)
-                .HasDefaultValueSql("('18991230')")
+                .HasDefaultValueSql("('18991230')", "DF_MGW10003_CFECHAAL01")
                 .HasColumnType("datetime");
             entity.Property(e => e.CFECHAEXTRA)
-                .HasDefaultValueSql("('18991230')")
+                .HasDefaultValueSql("('18991230')", "DF_MGW10003_CFECHAEX01")
                 .HasColumnType("datetime");
             entity.Property(e => e.CNOMBREALMACEN)
                 .HasMaxLength(60)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW10003_CNOMBREA01");
             entity.Property(e => e.CSCALMAC2)
                 .HasMaxLength(50)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW10003_CSCALMAC2");
             entity.Property(e => e.CSCALMAC3)
                 .HasMaxLength(50)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW10003_CSCALMAC3");
             entity.Property(e => e.CSEGCONTALMACEN)
                 .HasMaxLength(50)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW10003_CSEGCONT01");
             entity.Property(e => e.CTEXTOEXTRA1)
                 .HasMaxLength(50)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW10003_CTEXTOEX01");
             entity.Property(e => e.CTEXTOEXTRA2)
                 .HasMaxLength(50)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW10003_CTEXTOEX02");
             entity.Property(e => e.CTEXTOEXTRA3)
                 .HasMaxLength(50)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW10003_CTEXTOEX03");
             entity.Property(e => e.CTIMESTAMP)
                 .HasMaxLength(23)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW10003_CTIMESTAMP");
         });
 
         modelBuilder.Entity<admAperturas>(entity =>
@@ -319,34 +335,34 @@ public partial class ContpaqiComercialEmpresaDbContext : DbContext
             entity.HasIndex(e => new { e.CIDCAJA, e.CIDAPERTURA }, "CIDCAJA");
 
             entity.Property(e => e.CFECHAAPERTURA)
-                .HasDefaultValueSql("('18991230')")
+                .HasDefaultValueSql("('18991230')", "DF_admAperturas_CFECHAAPERTURA")
                 .HasColumnType("datetime");
             entity.Property(e => e.CFECHACORTE)
-                .HasDefaultValueSql("('18991230')")
+                .HasDefaultValueSql("('18991230')", "DF_admAperturas_CFECHACORTE")
                 .HasColumnType("datetime");
             entity.Property(e => e.CFECHAFACTURA)
-                .HasDefaultValueSql("('18991230')")
+                .HasDefaultValueSql("('18991230')", "DF_admAperturas_CFECHAFACTURA")
                 .HasColumnType("datetime");
             entity.Property(e => e.CHORAAPERTURA)
                 .HasMaxLength(6)
                 .IsUnicode(false)
-                .HasDefaultValue("000000");
+                .HasDefaultValue("000000", "DF_admAperturas_CHORAAPERTURA");
             entity.Property(e => e.CHORACORTE)
                 .HasMaxLength(6)
                 .IsUnicode(false)
-                .HasDefaultValue("000000");
+                .HasDefaultValue("000000", "DF_admAperturas_CHORACORTE");
             entity.Property(e => e.CTERMINAL)
                 .HasMaxLength(30)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_admAperturas_CTERMINAL");
             entity.Property(e => e.CTIMESTAMP)
                 .HasMaxLength(23)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_admAperturas_CTIMESTAMP");
             entity.Property(e => e.CUSUARIO)
                 .HasMaxLength(15)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_admAperturas_CUSUARIO");
         });
 
         modelBuilder.Entity<admAsientosContables>(entity =>
@@ -360,23 +376,23 @@ public partial class ContpaqiComercialEmpresaDbContext : DbContext
             entity.Property(e => e.CCONCEPTO)
                 .HasMaxLength(50)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW10023_CCONCEPTO");
             entity.Property(e => e.CDIARIO)
                 .HasMaxLength(10)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW10023_CDIARIO");
             entity.Property(e => e.CNOMBREASIENTOCONTABLE)
                 .HasMaxLength(60)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW10023_CNOMBREA01");
             entity.Property(e => e.CNUMEROASIENTOCONTABLE)
                 .HasMaxLength(30)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW10023_CNUMEROA01");
             entity.Property(e => e.CTIMESTAMP)
                 .HasMaxLength(23)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW10023_CTIMESTAMP");
         });
 
         modelBuilder.Entity<admAsocAcumConceptos>(entity =>
@@ -384,6 +400,22 @@ public partial class ContpaqiComercialEmpresaDbContext : DbContext
             entity.HasKey(e => e.CIDCONCEPTOTIPOACUMULADO);
 
             entity.HasIndex(e => new { e.CIDCONCEPTODOCUMENTO, e.CIMPORTEMODELO, e.CIDTIPOACUMULADO, e.CIDCONCEPTOTIPOACUMULADO }, "ICONCEPTOIMPORTETIPO");
+        });
+
+        modelBuilder.Entity<admAsocBuzones>(entity =>
+        {
+            entity.HasKey(e => new { e.CTIPOCATALOGO, e.CIDCATALOGO });
+
+            entity.Property(e => e.CINBOXID)
+                .HasMaxLength(40)
+                .IsUnicode(false)
+                .HasDefaultValue("", "DF_admAsocBuzones_CINBOXID");
+            entity.Property(e => e.CPASSWORD)
+                .HasMaxLength(60)
+                .IsUnicode(false)
+                .HasDefaultValue("", "DF_admBuzones_CPASSWORD");
+            entity.Property(e => e.CPRIVATEPEMKEY).IsUnicode(false);
+            entity.Property(e => e.CPUBLICPEMKEY).IsUnicode(false);
         });
 
         modelBuilder.Entity<admAsocCargosAbonos>(entity =>
@@ -395,7 +427,7 @@ public partial class ContpaqiComercialEmpresaDbContext : DbContext
             entity.HasIndex(e => new { e.CFECHAABONOCARGO, e.CIDAUTOINCSQL }, "PORFECHAABONOCARGO");
 
             entity.Property(e => e.CFECHAABONOCARGO)
-                .HasDefaultValueSql("('18991230')")
+                .HasDefaultValueSql("('18991230')", "DF_MGW10009_CFECHAAB01")
                 .HasColumnType("datetime");
             entity.Property(e => e.CIDAUTOINCSQL).ValueGeneratedOnAdd();
         });
@@ -417,15 +449,20 @@ public partial class ContpaqiComercialEmpresaDbContext : DbContext
             entity.Property(e => e.CMETODOPAG)
                 .HasMaxLength(100)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW10059_CMETODOPAG");
             entity.Property(e => e.CNOMIMPLOC)
                 .HasMaxLength(60)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW10059_CNOMIMPLOC");
             entity.Property(e => e.COBJIMPU01)
                 .HasMaxLength(20)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW10059_COBJIMPU01");
+        });
+
+        modelBuilder.Entity<admAsocLigasPagos>(entity =>
+        {
+            entity.HasKey(e => new { e.CIDLIGA, e.CIDDOCTO });
         });
 
         modelBuilder.Entity<admBanderas>(entity =>
@@ -438,11 +475,11 @@ public partial class ContpaqiComercialEmpresaDbContext : DbContext
             entity.Property(e => e.CCLAVEISO)
                 .HasMaxLength(3)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_IMG10002_CCLAVEISO");
             entity.Property(e => e.CNOMBREBANDERA)
                 .HasMaxLength(40)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_IMG10002_CNOMBREB01");
         });
 
         modelBuilder.Entity<admBitacoras>(entity =>
@@ -458,55 +495,86 @@ public partial class ContpaqiComercialEmpresaDbContext : DbContext
             entity.HasIndex(e => new { e.USUARIO, e.IDBITACORA }, "USUARIO");
 
             entity.Property(e => e.CFECHAEX01)
-                .HasDefaultValueSql("('18991230')")
+                .HasDefaultValueSql("('18991230')", "DF_CAC60000_CFECHAEX01")
                 .HasColumnType("datetime");
             entity.Property(e => e.CTEXTOEX01)
                 .HasMaxLength(30)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_CAC60000_CTEXTOEX01");
             entity.Property(e => e.CTEXTOEX02)
                 .HasMaxLength(30)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_CAC60000_CTEXTOEX02");
             entity.Property(e => e.CTEXTOEX03)
                 .HasMaxLength(30)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_CAC60000_CTEXTOEX03");
             entity.Property(e => e.DATOS)
                 .HasMaxLength(100)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_CAC60000_DATOS");
             entity.Property(e => e.EQUIPO)
                 .HasMaxLength(256)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_CAC60000_EQUIPO");
             entity.Property(e => e.FECHA)
-                .HasDefaultValueSql("('18991230')")
+                .HasDefaultValueSql("('18991230')", "DF_CAC60000_FECHA")
                 .HasColumnType("datetime");
             entity.Property(e => e.HORA)
                 .HasMaxLength(4)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_CAC60000_HORA");
             entity.Property(e => e.NOMBRE)
                 .HasMaxLength(30)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_CAC60000_NOMBRE");
             entity.Property(e => e.NOMBRE2)
                 .HasMaxLength(30)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_CAC60000_NOMBRE2");
             entity.Property(e => e.PROCESO)
                 .HasMaxLength(100)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_CAC60000_PROCESO");
             entity.Property(e => e.USUARIO)
                 .HasMaxLength(15)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_CAC60000_USUARIO");
             entity.Property(e => e.USUARIO2)
                 .HasMaxLength(15)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_CAC60000_USUARIO2");
+        });
+
+        modelBuilder.Entity<admBuzones>(entity =>
+        {
+            entity.HasKey(e => new { e.CINBOXID, e.CSUBSCRIPTIONID });
+
+            entity.HasIndex(e => new { e.CINBOXID, e.CTIPO }, "ITIPO").IsUnique();
+
+            entity.Property(e => e.CINBOXID)
+                .HasMaxLength(40)
+                .IsUnicode(false)
+                .HasDefaultValue("", "DF_admBuzones_CINBOXID");
+            entity.Property(e => e.CSUBSCRIPTIONID)
+                .HasMaxLength(40)
+                .IsUnicode(false)
+                .HasDefaultValue("", "DF_admBuzones_CSUBSCRIPTIONID");
+            entity.Property(e => e.CALIAS)
+                .HasMaxLength(256)
+                .IsUnicode(false)
+                .HasDefaultValue("", "DF_admBuzones_CALIAS");
+            entity.Property(e => e.CCREATEDAT)
+                .HasDefaultValueSql("('18991230')", "DF_admBuzones_CCREATEDAT")
+                .HasColumnType("datetime");
+            entity.Property(e => e.CENCRYPTIONKEYID)
+                .HasMaxLength(40)
+                .IsUnicode(false)
+                .HasDefaultValue("", "DF_admBuzones_CENCRYPTIONKEYID");
+            entity.Property(e => e.CSUBSCRIPTIONKEY).IsUnicode(false);
+            entity.Property(e => e.CUPDATEDAT)
+                .HasDefaultValueSql("('18991230')", "DF_admBuzones_CUPDATEDAT")
+                .HasColumnType("datetime");
         });
 
         modelBuilder.Entity<admCajas>(entity =>
@@ -524,56 +592,56 @@ public partial class ContpaqiComercialEmpresaDbContext : DbContext
             entity.Property(e => e.CCODIGOCAJA)
                 .HasMaxLength(30)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_admCajas_CCODIGOCAJA");
             entity.Property(e => e.CFECHAALTA)
-                .HasDefaultValueSql("('18991230')")
+                .HasDefaultValueSql("('18991230')", "DF_admCajas_CFECHAALTA")
                 .HasColumnType("datetime");
             entity.Property(e => e.CFECHABAJA)
-                .HasDefaultValueSql("('18991230')")
+                .HasDefaultValueSql("('18991230')", "DF_admCajas_CFECHABAJA")
                 .HasColumnType("datetime");
             entity.Property(e => e.CFECHAEXTRA)
-                .HasDefaultValueSql("('18991230')")
+                .HasDefaultValueSql("('18991230')", "DF_admCajas_CFECHAEX01")
                 .HasColumnType("datetime");
             entity.Property(e => e.CNOMBRECAJA)
                 .HasMaxLength(60)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_admCajas_CNOMBRECAJA");
             entity.Property(e => e.CSERIEDEVN)
                 .HasMaxLength(11)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_admCajas_CSERIEDEVN");
             entity.Property(e => e.CSERIENOTA)
                 .HasMaxLength(11)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_admCajas_CSERIENOTA");
             entity.Property(e => e.CTEXTOEXTRA1)
                 .HasMaxLength(50)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_admCajas_CTEXTOEX01");
             entity.Property(e => e.CTEXTOEXTRA2)
                 .HasMaxLength(50)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_admCajas_CTEXTOEX02");
             entity.Property(e => e.CTEXTOEXTRA3)
                 .HasMaxLength(50)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_admCajas_CTEXTOEX03");
             entity.Property(e => e.CTIMESTAMP)
                 .HasMaxLength(23)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_admCajas_CTIMESTAMP");
             entity.Property(e => e.cReporteApertura)
                 .HasMaxLength(60)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_admCajas_cReporteApertura");
             entity.Property(e => e.cReporteCorte)
                 .HasMaxLength(60)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_admCajas_cReporteCorte");
             entity.Property(e => e.cReporteNota)
                 .HasMaxLength(60)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_admCajas_cReporteNota");
         });
 
         modelBuilder.Entity<admCapasProducto>(entity =>
@@ -609,35 +677,35 @@ public partial class ContpaqiComercialEmpresaDbContext : DbContext
             entity.Property(e => e.CADUANA)
                 .HasMaxLength(60)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW10025_CADUANA");
             entity.Property(e => e.CCLAVESAT)
                 .HasMaxLength(30)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW10025_CCLAVESAT");
             entity.Property(e => e.CFECHA)
-                .HasDefaultValueSql("('18991230')")
+                .HasDefaultValueSql("('18991230')", "DF_MGW10025_CFECHA")
                 .HasColumnType("datetime");
             entity.Property(e => e.CFECHACADUCIDAD)
-                .HasDefaultValueSql("('18991230')")
+                .HasDefaultValueSql("('18991230')", "DF_MGW10025_CFECHACA01")
                 .HasColumnType("datetime");
             entity.Property(e => e.CFECHAFABRICACION)
-                .HasDefaultValueSql("('18991230')")
+                .HasDefaultValueSql("('18991230')", "DF_MGW10025_CFECHAFA01")
                 .HasColumnType("datetime");
             entity.Property(e => e.CFECHAPEDIMENTO)
-                .HasDefaultValueSql("('18991230')")
+                .HasDefaultValueSql("('18991230')", "DF_MGW10025_CFECHAPE01")
                 .HasColumnType("datetime");
             entity.Property(e => e.CNUMEROLOTE)
                 .HasMaxLength(30)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW10025_CNUMEROL01");
             entity.Property(e => e.CPEDIMENTO)
                 .HasMaxLength(30)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW10025_CPEDIMENTO");
             entity.Property(e => e.CTIMESTAMP)
                 .HasMaxLength(23)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW10025_CTIMESTAMP");
         });
 
         modelBuilder.Entity<admCaracteristicas>(entity =>
@@ -649,7 +717,7 @@ public partial class ContpaqiComercialEmpresaDbContext : DbContext
             entity.Property(e => e.CNOMBRECARACTERISTICA)
                 .HasMaxLength(60)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW10021_CNOMBREC01");
         });
 
         modelBuilder.Entity<admCaracteristicasValores>(entity =>
@@ -669,11 +737,11 @@ public partial class ContpaqiComercialEmpresaDbContext : DbContext
             entity.Property(e => e.CNEMOCARACTERISTICA)
                 .HasMaxLength(3)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW10022_CNEMOCAR01");
             entity.Property(e => e.CVALORCARACTERISTICA)
                 .HasMaxLength(20)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW10022_CVALORCA01");
         });
 
         modelBuilder.Entity<admClasificaciones>(entity =>
@@ -685,7 +753,7 @@ public partial class ContpaqiComercialEmpresaDbContext : DbContext
             entity.Property(e => e.CNOMBRECLASIFICACION)
                 .HasMaxLength(60)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW10019_CNOMBREC01");
         });
 
         modelBuilder.Entity<admClasificacionesValores>(entity =>
@@ -703,28 +771,30 @@ public partial class ContpaqiComercialEmpresaDbContext : DbContext
             entity.Property(e => e.CCODIGOVALORCLASIFICACION)
                 .HasMaxLength(3)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW10020_CCODIGOV01");
             entity.Property(e => e.CSEGCONT1)
                 .HasMaxLength(50)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW10020_CSEGCONT1");
             entity.Property(e => e.CSEGCONT2)
                 .HasMaxLength(50)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW10020_CSEGCONT2");
             entity.Property(e => e.CSEGCONT3)
                 .HasMaxLength(50)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW10020_CSEGCONT3");
             entity.Property(e => e.CVALORCLASIFICACION)
                 .HasMaxLength(60)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW10020_CVALORCL01");
         });
 
         modelBuilder.Entity<admClientes>(entity =>
         {
             entity.HasKey(e => e.CIDCLIENTEPROVEEDOR);
+
+            entity.HasIndex(e => new { e.CCODIGOALTERNO, e.CIDCLIENTEPROVEEDOR }, "CCODIGOALTERNO");
 
             entity.HasIndex(e => e.CCODIGOCLIENTE, "CCODIGOCLIENTE").IsUnique();
 
@@ -772,182 +842,186 @@ public partial class ContpaqiComercialEmpresaDbContext : DbContext
 
             entity.HasIndex(e => new { e.CRFC, e.CTIPOCLIENTE, e.CIDCLIENTEPROVEEDOR }, "IRFCTIPO");
 
+            entity.Property(e => e.CCODIGOALTERNO)
+                .HasMaxLength(60)
+                .IsUnicode(false)
+                .HasDefaultValue("", "DF_MGW10002_CCODIGOALTERNO");
             entity.Property(e => e.CCODIGOCLIENTE)
                 .HasMaxLength(30)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW10002_CCODIGOC01");
             entity.Property(e => e.CCODPROVCO)
                 .HasMaxLength(60)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW10002_CCODPROVCO");
             entity.Property(e => e.CCON1NOM)
                 .HasMaxLength(60)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW10002_CCON1NOM");
             entity.Property(e => e.CCON1TEL)
                 .HasMaxLength(15)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW10002_CCON1TEL");
             entity.Property(e => e.CCUENTAMENSAJERIA)
                 .HasMaxLength(60)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW10002_CCUENTAM01");
             entity.Property(e => e.CCURP)
                 .HasMaxLength(20)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW10002_CCURP");
             entity.Property(e => e.CDENCOMERCIAL)
                 .HasMaxLength(50)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW10002_CDENCOME01");
             entity.Property(e => e.CEMAIL1)
                 .HasMaxLength(60)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW10002_CEMAIL1");
             entity.Property(e => e.CEMAIL2)
                 .HasMaxLength(60)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW10002_CEMAIL2");
             entity.Property(e => e.CEMAIL3)
                 .HasMaxLength(60)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW10002_CEMAIL3");
             entity.Property(e => e.CFECHAALTA)
-                .HasDefaultValueSql("('18991230')")
+                .HasDefaultValueSql("('18991230')", "DF_MGW10002_CFECHAALTA")
                 .HasColumnType("datetime");
             entity.Property(e => e.CFECHABAJA)
-                .HasDefaultValueSql("('18991230')")
+                .HasDefaultValueSql("('18991230')", "DF_MGW10002_CFECHABAJA")
                 .HasColumnType("datetime");
             entity.Property(e => e.CFECHAEXTRA)
-                .HasDefaultValueSql("('18991230')")
+                .HasDefaultValueSql("('18991230')", "DF_MGW10002_CFECHAEX01")
                 .HasColumnType("datetime");
             entity.Property(e => e.CFECHAULTIMAREVISION)
-                .HasDefaultValueSql("('18991230')")
+                .HasDefaultValueSql("('18991230')", "DF_MGW10002_CFECHAUL01")
                 .HasColumnType("datetime");
             entity.Property(e => e.CMENSAJERIA)
                 .HasMaxLength(20)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW10002_CMENSAJE01");
             entity.Property(e => e.CMETODOPAG)
                 .HasMaxLength(100)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW10002_CMETODOPAG");
             entity.Property(e => e.CNUMCTAPAG)
                 .HasMaxLength(100)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW10002_CNUMCTAPAG");
             entity.Property(e => e.CRAZONSOCIAL)
                 .HasMaxLength(60)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW10002_CRAZONSO01");
             entity.Property(e => e.CREGIMFISC)
                 .HasMaxLength(20)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW10002_CREGIMFISC");
             entity.Property(e => e.CREPLEGAL)
                 .HasMaxLength(50)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW10002_CREPLEGAL");
             entity.Property(e => e.CRFC)
                 .HasMaxLength(20)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW10002_CRFC");
             entity.Property(e => e.CSEGCONTCLIENTE1)
                 .HasMaxLength(50)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW10002_CSEGCONT01");
             entity.Property(e => e.CSEGCONTCLIENTE2)
                 .HasMaxLength(50)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW10002_CSEGCONT02");
             entity.Property(e => e.CSEGCONTCLIENTE3)
                 .HasMaxLength(50)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW10002_CSEGCONT03");
             entity.Property(e => e.CSEGCONTCLIENTE4)
                 .HasMaxLength(50)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW10002_CSEGCONT04");
             entity.Property(e => e.CSEGCONTCLIENTE5)
                 .HasMaxLength(50)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW10002_CSEGCONT05");
             entity.Property(e => e.CSEGCONTCLIENTE6)
                 .HasMaxLength(50)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW10002_CSEGCONT06");
             entity.Property(e => e.CSEGCONTCLIENTE7)
                 .HasMaxLength(50)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW10002_CSEGCONT07");
             entity.Property(e => e.CSEGCONTPROVEEDOR1)
                 .HasMaxLength(50)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW10002_CSEGCONT08");
             entity.Property(e => e.CSEGCONTPROVEEDOR2)
                 .HasMaxLength(50)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW10002_CSEGCONT09");
             entity.Property(e => e.CSEGCONTPROVEEDOR3)
                 .HasMaxLength(50)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW10002_CSEGCONT10");
             entity.Property(e => e.CSEGCONTPROVEEDOR4)
                 .HasMaxLength(50)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW10002_CSEGCONT11");
             entity.Property(e => e.CSEGCONTPROVEEDOR5)
                 .HasMaxLength(50)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW10002_CSEGCONT12");
             entity.Property(e => e.CSEGCONTPROVEEDOR6)
                 .HasMaxLength(50)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW10002_CSEGCONT13");
             entity.Property(e => e.CSEGCONTPROVEEDOR7)
                 .HasMaxLength(50)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW10002_CSEGCONT14");
             entity.Property(e => e.CSITIOFTP)
                 .HasMaxLength(60)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW10002_CSITIOFTP");
             entity.Property(e => e.CTEXTOEXTRA1)
                 .HasMaxLength(50)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW10002_CTEXTOEX01");
             entity.Property(e => e.CTEXTOEXTRA2)
                 .HasMaxLength(50)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW10002_CTEXTOEX02");
             entity.Property(e => e.CTEXTOEXTRA3)
                 .HasMaxLength(50)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW10002_CTEXTOEX03");
             entity.Property(e => e.CTEXTOEXTRA4)
                 .HasMaxLength(50)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW10002_CTEXTOEX04");
             entity.Property(e => e.CTEXTOEXTRA5)
                 .HasMaxLength(50)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW10002_CTEXTOEX05");
             entity.Property(e => e.CTIMESTAMP)
                 .HasMaxLength(23)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW10002_CTIMESTAMP");
             entity.Property(e => e.CUSOCFDI)
                 .HasMaxLength(30)
                 .IsUnicode(false)
-                .HasDefaultValue("P01");
+                .HasDefaultValue("P01", "DF_MGW10002_CUSOCFDI");
             entity.Property(e => e.CUSRFTP)
                 .HasMaxLength(60)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW10002_CUSRFTP");
             entity.Property(e => e.CWHATSAPP)
                 .HasMaxLength(15)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW10002_CWHATSAPP");
         });
 
         modelBuilder.Entity<admComponentesPaquete>(entity =>
@@ -982,80 +1056,80 @@ public partial class ContpaqiComercialEmpresaDbContext : DbContext
             entity.Property(e => e.CCLAVESAT)
                 .HasMaxLength(8)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW10006_CCLAVESAT");
             entity.Property(e => e.CCODIGOCONCEPTO)
                 .HasMaxLength(30)
                 .IsUnicode(false)
-                .HasDefaultValue("");
-            entity.Property(e => e.CESTATUS).HasDefaultValue(1);
+                .HasDefaultValue("", "DF_MGW10006_CCODIGOC01");
+            entity.Property(e => e.CESTATUS).HasDefaultValue(1, "DF_MGW10006_CESTATUS");
             entity.Property(e => e.CFORMAPREIMPRESA)
                 .HasMaxLength(253)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW10006_CFORMAPR01");
             entity.Property(e => e.CIDFIRMADSL)
                 .HasMaxLength(40)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW10006_CIDFIRMDSL");
             entity.Property(e => e.CMETODOPAG)
                 .HasMaxLength(100)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW10006_CMETODOPAG");
             entity.Property(e => e.CNOMBRECONCEPTO)
                 .HasMaxLength(60)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW10006_CNOMBREC01");
             entity.Property(e => e.CORDENCAPTURA)
                 .HasMaxLength(52)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW10006_CIDORDENCAPTURA");
             entity.Property(e => e.CPLAMIGCFD)
                 .HasMaxLength(253)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW10006_CPLAMIGCFD");
             entity.Property(e => e.CPREFIJOCONCEPTO)
                 .HasMaxLength(30)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW10006_CPREFICON");
             entity.Property(e => e.CREGIMFISC)
                 .HasMaxLength(100)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW10006_CREGIMFISC");
             entity.Property(e => e.CREPIMPCFD)
                 .HasMaxLength(253)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW10006_CREPIMPCFD");
             entity.Property(e => e.CRUTAENTREGA)
                 .HasMaxLength(253)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW10006_CRUTAENT01");
             entity.Property(e => e.CSCCPTO2)
                 .HasMaxLength(50)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW10006_CSCCPTO2");
             entity.Property(e => e.CSCCPTO3)
                 .HasMaxLength(50)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW10006_CSCCPTO3");
             entity.Property(e => e.CSCMOVTO)
                 .HasMaxLength(50)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW10006_CSCMOVTO");
             entity.Property(e => e.CSEGCONTCONCEPTO)
                 .HasMaxLength(50)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW10006_CSEGCONT01");
             entity.Property(e => e.CSERIEPOROMISION)
                 .HasMaxLength(11)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW10006_CSERIEPO01");
             entity.Property(e => e.CTIMESTAMP)
                 .HasMaxLength(23)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW10006_CTIMESTAMP");
             entity.Property(e => e.CVERESQUE)
                 .HasMaxLength(6)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW10006_CVERESQUE");
         });
 
         modelBuilder.Entity<admConceptosBack>(entity =>
@@ -1071,79 +1145,84 @@ public partial class ContpaqiComercialEmpresaDbContext : DbContext
             entity.Property(e => e.CCLAVESAT)
                 .HasMaxLength(8)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_BACK10006_CCLAVESAT");
             entity.Property(e => e.CCODIGOCONCEPTO)
                 .HasMaxLength(30)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_BACK10006_CCODIGOC01");
             entity.Property(e => e.CFORMAPREIMPRESA)
                 .HasMaxLength(253)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_BACK10006_CFORMAPR01");
             entity.Property(e => e.CIDFIRMADSL)
                 .HasMaxLength(40)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_BACK10006_CIDFIRMDSL");
             entity.Property(e => e.CMETODOPAG)
                 .HasMaxLength(100)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_BACK10006_CMETODOPAG");
             entity.Property(e => e.CNOMBRECONCEPTO)
                 .HasMaxLength(60)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_BACK10006_CNOMBREC01");
             entity.Property(e => e.CORDENCAPTURA)
                 .HasMaxLength(52)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_BACK10006_CORDENCAPTURA");
             entity.Property(e => e.CPLAMIGCFD)
                 .HasMaxLength(253)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_BACK10006_CPLAMIGCFD");
             entity.Property(e => e.CPREFIJOCONCEPTO)
                 .HasMaxLength(30)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_BACK10006_CPREFICON");
             entity.Property(e => e.CREGIMFISC)
                 .HasMaxLength(100)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_BACK10006_CREGIMFISC");
             entity.Property(e => e.CREPIMPCFD)
                 .HasMaxLength(253)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_BACK10006_CREPIMPCFD");
             entity.Property(e => e.CRUTAENTREGA)
                 .HasMaxLength(253)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_BACK10006_CRUTAENT01");
             entity.Property(e => e.CSCCPTO2)
                 .HasMaxLength(50)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_BACK10006_CSCCPTO2");
             entity.Property(e => e.CSCCPTO3)
                 .HasMaxLength(50)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_BACK10006_CSCCPTO3");
             entity.Property(e => e.CSCMOVTO)
                 .HasMaxLength(50)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_BACK10006_CSCMOVTO");
             entity.Property(e => e.CSEGCONTCONCEPTO)
                 .HasMaxLength(50)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_BACK10006_CSEGCONT01");
             entity.Property(e => e.CSERIEPOROMISION)
                 .HasMaxLength(11)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_BACK10006_CSERIEPO01");
             entity.Property(e => e.CTIMESTAMP)
                 .HasMaxLength(23)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_BACK10006_CTIMESTAMP");
             entity.Property(e => e.CVERESQUE)
                 .HasMaxLength(6)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_BACK10006_CVERESQUE");
+        });
+
+        modelBuilder.Entity<admConfigProveedoresNube>(entity =>
+        {
+            entity.HasKey(e => e.CIDPROVEEDORSERVICIO);
         });
 
         modelBuilder.Entity<admConversionesUnidad>(entity =>
@@ -1155,8 +1234,8 @@ public partial class ContpaqiComercialEmpresaDbContext : DbContext
             entity.Property(e => e.CEXPRESIONFACTOR)
                 .HasMaxLength(11)
                 .IsUnicode(false)
-                .HasDefaultValue("");
-            entity.Property(e => e.CFACTORCONVERSION).HasDefaultValueSql("('')");
+                .HasDefaultValue("", "DF_MGW10027_CEXPRESIONFACTOR");
+            entity.Property(e => e.CFACTORCONVERSION).HasDefaultValueSql("('')", "DF_MGW10027_CFACTORC01");
             entity.Property(e => e.CIDAUTOINCSQL).ValueGeneratedOnAdd();
         });
 
@@ -1167,12 +1246,12 @@ public partial class ContpaqiComercialEmpresaDbContext : DbContext
             entity.HasIndex(e => new { e.CIDPRODUCTO, e.CIDALMACEN, e.CFECHACOSTOH }, "IPRODALMACENFECHA");
 
             entity.Property(e => e.CFECHACOSTOH)
-                .HasDefaultValueSql("('18991230')")
+                .HasDefaultValueSql("('18991230')", "DF_MGW10017_CFECHACO01")
                 .HasColumnType("datetime");
             entity.Property(e => e.CTIMESTAMP)
                 .HasMaxLength(23)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW10017_CTIMESTAMP");
         });
 
         modelBuilder.Entity<admCuentasBancarias>(entity =>
@@ -1188,68 +1267,68 @@ public partial class ContpaqiComercialEmpresaDbContext : DbContext
             entity.Property(e => e.CACCOUNTID)
                 .HasMaxLength(26)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_admCuentasBancarias_CACCOUNTID");
             entity.Property(e => e.CCLABE)
                 .HasMaxLength(20)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_admCuentasBancarias_CCLABE");
             entity.Property(e => e.CCLAVE)
                 .HasMaxLength(3)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_admCuentasBancarias_CCLAVE");
             entity.Property(e => e.CFECHAALTA)
-                .HasDefaultValueSql("('18991230')")
+                .HasDefaultValueSql("('18991230')", "DF_admCuentasBancarias_CFECHAALTA")
                 .HasColumnType("datetime");
             entity.Property(e => e.CFECHABAJA)
-                .HasDefaultValueSql("('18991230')")
+                .HasDefaultValueSql("('18991230')", "DF_admCuentasBancarias_CFECHABAJA")
                 .HasColumnType("datetime");
             entity.Property(e => e.CFECHAEXTRA)
-                .HasDefaultValueSql("('18991230')")
+                .HasDefaultValueSql("('18991230')", "DF_admCuentasBancarias_CFECHAEX01")
                 .HasColumnType("datetime");
             entity.Property(e => e.CNOMBANEXT)
                 .HasMaxLength(254)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_admCuentasBancarias_CNOMBANEXT");
             entity.Property(e => e.CNOMBRECUENTA)
                 .HasMaxLength(60)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_admCuentasBancarias_CNOMBRECUENTA");
             entity.Property(e => e.CNUMEROCUENTA)
                 .HasMaxLength(30)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_admCuentasBancarias_CNUMEROCUENTA");
             entity.Property(e => e.CRFCBANCO)
                 .HasMaxLength(20)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_admCuentasBancarias_CRFCBANCO");
             entity.Property(e => e.CSEGCONT01)
                 .HasMaxLength(50)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_admCuentasBancarias_CSEGCONT01");
             entity.Property(e => e.CSEGCONT02)
                 .HasMaxLength(50)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_admCuentasBancarias_CSEGCONT02");
             entity.Property(e => e.CSEGCONT03)
                 .HasMaxLength(50)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_admCuentasBancarias_CSEGCONT03");
             entity.Property(e => e.CTEXTOEXTRA1)
                 .HasMaxLength(50)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_admCuentasBancarias_CTEXTOEX01");
             entity.Property(e => e.CTEXTOEXTRA2)
                 .HasMaxLength(50)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_admCuentasBancarias_CTEXTOEX02");
             entity.Property(e => e.CTEXTOEXTRA3)
                 .HasMaxLength(50)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_admCuentasBancarias_CTEXTOEX03");
             entity.Property(e => e.CTIMESTAMP)
                 .HasMaxLength(23)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_admCuentasBancarias_CTIMESTAMP");
         });
 
         modelBuilder.Entity<admDatosAddenda>(entity =>
@@ -1262,7 +1341,7 @@ public partial class ContpaqiComercialEmpresaDbContext : DbContext
             entity.Property(e => e.VALOR)
                 .HasMaxLength(254)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW10046_VALOR");
         });
 
         modelBuilder.Entity<admDocumentos>(entity =>
@@ -1323,106 +1402,117 @@ public partial class ContpaqiComercialEmpresaDbContext : DbContext
 
             entity.HasIndex(e => new { e.CIDCLIENTEPROVEEDOR, e.CNATURALEZA, e.CAFECTADO, e.CFECHAVENCIMIENTO, e.CPENDIENTE }, "RIDCLINATAFEC");
 
+            entity.Property(e => e.CCODIGOFACTURACION)
+                .HasMaxLength(40)
+                .IsUnicode(false)
+                .HasDefaultValue("", "DF_MGW10008_CCODIGOFACTURACION");
             entity.Property(e => e.CCONDIPAGO)
                 .HasMaxLength(253)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW10008_CCONDIPAGO");
             entity.Property(e => e.CCUENTAMENSAJERIA)
                 .HasMaxLength(120)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW10008_CCUENTAM01");
             entity.Property(e => e.CDATOSADICIONALES).IsUnicode(false);
             entity.Property(e => e.CDESTINATARIO)
                 .HasMaxLength(60)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW10008_CDESTINA01");
             entity.Property(e => e.CFECHA)
-                .HasDefaultValueSql("('18991230')")
+                .HasDefaultValueSql("('18991230')", "DF_MGW10008_CFECHA")
                 .HasColumnType("datetime");
             entity.Property(e => e.CFECHAENTREGARECEPCION)
-                .HasDefaultValueSql("('18991230')")
+                .HasDefaultValueSql("('18991230')", "DF_MGW10008_CFECHAEN01")
                 .HasColumnType("datetime");
             entity.Property(e => e.CFECHAEXTRA)
-                .HasDefaultValueSql("('18991230')")
+                .HasDefaultValueSql("('18991230')", "DF_MGW10008_CFECHAEX01")
+                .HasColumnType("datetime");
+            entity.Property(e => e.CFECHAFACTURACION)
+                .HasDefaultValueSql("('18991230')", "DF_MGW10008_CFECHAFACTURACION")
                 .HasColumnType("datetime");
             entity.Property(e => e.CFECHAPRONTOPAGO)
-                .HasDefaultValueSql("('18991230')")
+                .HasDefaultValueSql("('18991230')", "DF_MGW10008_CFECHAPR01")
                 .HasColumnType("datetime");
             entity.Property(e => e.CFECHAULTIMOINTERES)
-                .HasDefaultValueSql("('18991230')")
+                .HasDefaultValueSql("('18991230')", "DF_MGW10008_CFECHAUL01")
                 .HasColumnType("datetime");
             entity.Property(e => e.CFECHAVENCIMIENTO)
-                .HasDefaultValueSql("('18991230')")
+                .HasDefaultValueSql("('18991230')", "DF_MGW10008_CFECHAVE01")
                 .HasColumnType("datetime");
             entity.Property(e => e.CGUIDDOCUMENTO)
                 .HasMaxLength(40)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW10008_CGUIDDOCUMENTO");
             entity.Property(e => e.CLUGAREXPE)
                 .HasMaxLength(380)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW10008_CLUGAREXPE");
             entity.Property(e => e.CMENSAJERIA)
                 .HasMaxLength(20)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW10008_CMENSAJE01");
             entity.Property(e => e.CMETODOPAG)
                 .HasMaxLength(100)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW10008_CMETODOPAG");
             entity.Property(e => e.CNUMCTAPAG)
                 .HasMaxLength(100)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW10008_CNUMCTAPAG");
             entity.Property(e => e.CNUMEROGUIA)
                 .HasMaxLength(60)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW10008_CNUMEROG01");
             entity.Property(e => e.COBSERVACIONES).HasColumnType("text");
             entity.Property(e => e.CRAZONSOCIAL)
                 .HasMaxLength(60)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW10008_CRAZONSO01");
             entity.Property(e => e.CREFERENCIA)
                 .HasMaxLength(20)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW10008_CREFEREN01");
             entity.Property(e => e.CRFC)
                 .HasMaxLength(20)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW10008_CRFC");
             entity.Property(e => e.CSERIEDOCUMENTO)
                 .HasMaxLength(11)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW10008_CSERIEDO01");
             entity.Property(e => e.CTEXTOEXTRA1)
                 .HasMaxLength(50)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW10008_CTEXTOEX01");
             entity.Property(e => e.CTEXTOEXTRA2)
                 .HasMaxLength(50)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW10008_CTEXTOEX02");
             entity.Property(e => e.CTEXTOEXTRA3)
                 .HasMaxLength(50)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW10008_CTEXTOEX03");
+            entity.Property(e => e.CTICKETID)
+                .HasMaxLength(40)
+                .IsUnicode(false)
+                .HasDefaultValue("", "DF_MGW10008_CTICKETID");
             entity.Property(e => e.CTIMESTAMP)
                 .HasMaxLength(23)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW10008_CTIMESTAMP");
             entity.Property(e => e.CTRANSACTIONID)
                 .HasMaxLength(26)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW10008_CTRANSACTIONID");
             entity.Property(e => e.CUSUARIO)
                 .HasMaxLength(15)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW10008_CUSUARIO");
             entity.Property(e => e.CVERESQUE)
                 .HasMaxLength(6)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW10008_CVERESQUE");
         });
 
         modelBuilder.Entity<admDocumentosModelo>(entity =>
@@ -1438,7 +1528,7 @@ public partial class ContpaqiComercialEmpresaDbContext : DbContext
             entity.Property(e => e.CDESCRIPCION)
                 .HasMaxLength(50)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW10007_CDESCRIP01");
         });
 
         modelBuilder.Entity<admDocumentosModelosBack>(entity =>
@@ -1454,7 +1544,20 @@ public partial class ContpaqiComercialEmpresaDbContext : DbContext
             entity.Property(e => e.CDESCRIPCION)
                 .HasMaxLength(50)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_BACK10007_CDESCRIP01");
+        });
+
+        modelBuilder.Entity<admDocumentosOrigen>(entity =>
+        {
+            entity.HasKey(e => e.CIDDOCUMENTO);
+
+            entity.Property(e => e.CFECHA)
+                .HasDefaultValueSql("('18991230')", "DF_admDocumentosOrigen_CFECHA")
+                .HasColumnType("datetime");
+            entity.Property(e => e.CSERIE)
+                .HasMaxLength(11)
+                .IsUnicode(false)
+                .HasDefaultValue("", "DF_admDocumentosOrigen_CSERIE");
         });
 
         modelBuilder.Entity<admDomicilios>(entity =>
@@ -1472,75 +1575,75 @@ public partial class ContpaqiComercialEmpresaDbContext : DbContext
             entity.Property(e => e.CCIUDAD)
                 .HasMaxLength(60)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW10011_CCIUDAD");
             entity.Property(e => e.CCODIGOPOSTAL)
                 .HasMaxLength(6)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW10011_CCODIGOP01");
             entity.Property(e => e.CCOLONIA)
                 .HasMaxLength(60)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW10011_CCOLONIA");
             entity.Property(e => e.CDIRECCIONWEB)
                 .HasMaxLength(50)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW10011_CDIRECCI01");
             entity.Property(e => e.CEMAIL)
                 .HasMaxLength(50)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW10011_CEMAIL");
             entity.Property(e => e.CESTADO)
                 .HasMaxLength(60)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW10011_CESTADO");
             entity.Property(e => e.CMUNICIPIO)
                 .HasMaxLength(60)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW10011_CMUNICIPIO");
             entity.Property(e => e.CNOMBRECALLE)
                 .HasMaxLength(60)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW10011_CNOMBREC01");
             entity.Property(e => e.CNUMEROEXTERIOR)
                 .HasMaxLength(30)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW10011_CNUMEROE01");
             entity.Property(e => e.CNUMEROINTERIOR)
                 .HasMaxLength(30)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW10011_CNUMEROI01");
             entity.Property(e => e.CPAIS)
                 .HasMaxLength(60)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW10011_CPAIS");
             entity.Property(e => e.CSUCURSAL)
                 .HasMaxLength(60)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW10011_CSUCURSAL");
             entity.Property(e => e.CTELEFONO1)
                 .HasMaxLength(15)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW10011_CTELEFONO1");
             entity.Property(e => e.CTELEFONO2)
                 .HasMaxLength(15)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW10011_CTELEFONO2");
             entity.Property(e => e.CTELEFONO3)
                 .HasMaxLength(15)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW10011_CTELEFONO3");
             entity.Property(e => e.CTELEFONO4)
                 .HasMaxLength(15)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW10011_CTELEFONO4");
             entity.Property(e => e.CTEXTOEXTRA)
                 .HasMaxLength(60)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW10011_CTEXTOEX01");
             entity.Property(e => e.CTIMESTAMP)
                 .HasMaxLength(23)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW10011_CTIMESTAMP");
         });
 
         modelBuilder.Entity<admEjercicios>(entity =>
@@ -1550,43 +1653,43 @@ public partial class ContpaqiComercialEmpresaDbContext : DbContext
             entity.HasIndex(e => e.CNUMEROEJERCICIO, "CNUMEROEJERCICIO");
 
             entity.Property(e => e.CFECHAFINAL)
-                .HasDefaultValueSql("('18991230')")
+                .HasDefaultValueSql("('18991230')", "DF_MGW10031_CFECHAFI01")
                 .HasColumnType("datetime");
             entity.Property(e => e.CFECINIPERIODO1)
-                .HasDefaultValueSql("('18991230')")
+                .HasDefaultValueSql("('18991230')", "DF_MGW10031_CFECINIP01")
                 .HasColumnType("datetime");
             entity.Property(e => e.CFECINIPERIODO10)
-                .HasDefaultValueSql("('18991230')")
+                .HasDefaultValueSql("('18991230')", "DF_MGW10031_CFECINIP10")
                 .HasColumnType("datetime");
             entity.Property(e => e.CFECINIPERIODO11)
-                .HasDefaultValueSql("('18991230')")
+                .HasDefaultValueSql("('18991230')", "DF_MGW10031_CFECINIP11")
                 .HasColumnType("datetime");
             entity.Property(e => e.CFECINIPERIODO12)
-                .HasDefaultValueSql("('18991230')")
+                .HasDefaultValueSql("('18991230')", "DF_MGW10031_CFECINIP12")
                 .HasColumnType("datetime");
             entity.Property(e => e.CFECINIPERIODO2)
-                .HasDefaultValueSql("('18991230')")
+                .HasDefaultValueSql("('18991230')", "DF_MGW10031_CFECINIP02")
                 .HasColumnType("datetime");
             entity.Property(e => e.CFECINIPERIODO3)
-                .HasDefaultValueSql("('18991230')")
+                .HasDefaultValueSql("('18991230')", "DF_MGW10031_CFECINIP03")
                 .HasColumnType("datetime");
             entity.Property(e => e.CFECINIPERIODO4)
-                .HasDefaultValueSql("('18991230')")
+                .HasDefaultValueSql("('18991230')", "DF_MGW10031_CFECINIP04")
                 .HasColumnType("datetime");
             entity.Property(e => e.CFECINIPERIODO5)
-                .HasDefaultValueSql("('18991230')")
+                .HasDefaultValueSql("('18991230')", "DF_MGW10031_CFECINIP05")
                 .HasColumnType("datetime");
             entity.Property(e => e.CFECINIPERIODO6)
-                .HasDefaultValueSql("('18991230')")
+                .HasDefaultValueSql("('18991230')", "DF_MGW10031_CFECINIP06")
                 .HasColumnType("datetime");
             entity.Property(e => e.CFECINIPERIODO7)
-                .HasDefaultValueSql("('18991230')")
+                .HasDefaultValueSql("('18991230')", "DF_MGW10031_CFECINIP07")
                 .HasColumnType("datetime");
             entity.Property(e => e.CFECINIPERIODO8)
-                .HasDefaultValueSql("('18991230')")
+                .HasDefaultValueSql("('18991230')", "DF_MGW10031_CFECINIP08")
                 .HasColumnType("datetime");
             entity.Property(e => e.CFECINIPERIODO9)
-                .HasDefaultValueSql("('18991230')")
+                .HasDefaultValueSql("('18991230')", "DF_MGW10031_CFECINIP09")
                 .HasColumnType("datetime");
         });
 
@@ -1605,7 +1708,7 @@ public partial class ContpaqiComercialEmpresaDbContext : DbContext
             entity.Property(e => e.CTIMESTAMP)
                 .HasMaxLength(23)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW10030_CTIMESTAMP");
         });
 
         modelBuilder.Entity<admFoliosDigitales>(entity =>
@@ -1673,140 +1776,140 @@ public partial class ContpaqiComercialEmpresaDbContext : DbContext
             entity.Property(e => e.CACUSECAN)
                 .HasMaxLength(30)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW10045_CACUSECAN");
             entity.Property(e => e.CALIASBDCT)
                 .HasMaxLength(50)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW10045_CALIASBDCT");
             entity.Property(e => e.CARCHCBB)
                 .HasMaxLength(60)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW10045_CARCHCBB");
             entity.Property(e => e.CARCHDIDIS)
                 .HasMaxLength(253)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW10045_CARCHDIDIS");
             entity.Property(e => e.CCADPEDI).HasColumnType("text");
             entity.Property(e => e.CCODCONCBA)
                 .HasMaxLength(30)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW10045_CCODCONCBA");
             entity.Property(e => e.CDESCAUT01)
                 .HasMaxLength(20)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW10045_CDESCAUT01");
             entity.Property(e => e.CDESCAUT02)
                 .HasMaxLength(20)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW10045_CDESCAUT02");
             entity.Property(e => e.CDESCAUT03)
                 .HasMaxLength(20)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW10045_CDESCAUT03");
             entity.Property(e => e.CDESCONCBA)
                 .HasMaxLength(100)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW10045_CDESCONCBA");
             entity.Property(e => e.CDESESTADO)
                 .HasMaxLength(50)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW10045_CDESESTADO");
             entity.Property(e => e.CDESPAGBAN)
                 .HasMaxLength(20)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW10045_CDESPAGBAN");
             entity.Property(e => e.CEMAIL)
                 .HasMaxLength(60)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW10045_CEMAIL");
             entity.Property(e => e.CFECAPROB)
-                .HasDefaultValueSql("('18991230')")
+                .HasDefaultValueSql("('18991230')", "DF_MGW10045_CFECAPROB")
                 .HasColumnType("datetime");
             entity.Property(e => e.CFECHACANC)
-                .HasDefaultValueSql("('18991230')")
+                .HasDefaultValueSql("('18991230')", "DF_MGW10045_CFECHACANC")
                 .HasColumnType("datetime");
             entity.Property(e => e.CFECHAEMI)
-                .HasDefaultValueSql("('18991230')")
+                .HasDefaultValueSql("('18991230')", "DF_MGW10045_CFECHAEMI")
                 .HasColumnType("datetime");
             entity.Property(e => e.CFINVIG)
-                .HasDefaultValueSql("('18991230')")
+                .HasDefaultValueSql("('18991230')", "DF_MGW10045_CFINVIG")
                 .HasColumnType("datetime");
             entity.Property(e => e.CFOLIOBAN)
                 .HasMaxLength(20)
                 .IsUnicode(false)
-                .HasDefaultValue("");
-            entity.Property(e => e.CFOLIOREC).HasDefaultValue(0.0);
+                .HasDefaultValue("", "DF_MGW10045_CFOLIOBAN");
+            entity.Property(e => e.CFOLIOREC).HasDefaultValue(0.0, "DF_MGW10045_CFOLIOREC");
             entity.Property(e => e.CHORACANC)
                 .HasMaxLength(8)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW10045_CHORACANC");
             entity.Property(e => e.CHORAEMI)
                 .HasMaxLength(8)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW10045_CHORAEMI");
             entity.Property(e => e.CIDDOCTODSL)
                 .HasMaxLength(40)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW10045_CIDDOCDSL");
             entity.Property(e => e.CINIVIG)
-                .HasDefaultValueSql("('18991230')")
+                .HasDefaultValueSql("('18991230')", "DF_MGW10045_CINIVIG")
                 .HasColumnType("datetime");
             entity.Property(e => e.CNUMCTABAN)
                 .HasMaxLength(30)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW10045_CNUMCTABAN");
             entity.Property(e => e.COBSERVA01)
                 .HasMaxLength(253)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW10045_COBSERVA01");
             entity.Property(e => e.CRAZON)
                 .HasMaxLength(253)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW10045_CRAZON");
             entity.Property(e => e.CREFEREN01)
                 .HasMaxLength(20)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW10045_CREFEREN01");
             entity.Property(e => e.CRFC)
                 .HasMaxLength(20)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW10045_CRFC");
             entity.Property(e => e.CSERIE)
                 .HasMaxLength(10)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW10045_CSERIE");
             entity.Property(e => e.CSERIEREC)
                 .HasMaxLength(25)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW10045_CSERIEREC");
             entity.Property(e => e.CTIPO)
                 .HasMaxLength(1)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW10045_CTIPO");
             entity.Property(e => e.CTIPOLDESC)
                 .HasMaxLength(100)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW10045_CTIPOLDESC");
             entity.Property(e => e.CUSUAUTBAN)
                 .HasMaxLength(20)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW10045_CUSUAUTBAN");
             entity.Property(e => e.CUSUBAN01)
                 .HasMaxLength(20)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW10045_CUSUBAN01");
             entity.Property(e => e.CUSUBAN02)
                 .HasMaxLength(20)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW10045_CUSUBAN02");
             entity.Property(e => e.CUSUBAN03)
                 .HasMaxLength(20)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW10045_CUSUBAN03");
             entity.Property(e => e.CUUID)
                 .HasMaxLength(60)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW10045_CUUID");
         });
 
         modelBuilder.Entity<admFormasPago>(entity =>
@@ -1822,41 +1925,69 @@ public partial class ContpaqiComercialEmpresaDbContext : DbContext
             entity.Property(e => e.CCLAVESAT)
                 .HasMaxLength(3)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_admFormasPago_CCLAVESAT");
             entity.Property(e => e.CCODIGOFORMAPAGO)
                 .HasMaxLength(30)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_admFormasPago_CCODIGOFORMA");
             entity.Property(e => e.CFECHAALTA)
-                .HasDefaultValueSql("('18991230')")
+                .HasDefaultValueSql("('18991230')", "DF_admFormasPago_CFECHAALTA")
                 .HasColumnType("datetime");
             entity.Property(e => e.CFECHABAJA)
-                .HasDefaultValueSql("('18991230')")
+                .HasDefaultValueSql("('18991230')", "DF_admFormasPago_CFECHABAJA")
                 .HasColumnType("datetime");
             entity.Property(e => e.CFECHAEXTRA)
-                .HasDefaultValueSql("('18991230')")
+                .HasDefaultValueSql("('18991230')", "DF_admFormasPago_CFECHAEX01")
                 .HasColumnType("datetime");
-            entity.Property(e => e.CIDMONEDA).HasDefaultValue(1);
+            entity.Property(e => e.CIDMONEDA).HasDefaultValue(1, "DF_admFormasPago_CIDMONEDA");
             entity.Property(e => e.CNOMBREFORMAPAGO)
                 .HasMaxLength(60)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_admFormasPago_CNOMBREFORMA");
             entity.Property(e => e.CTEXTOEXTRA1)
                 .HasMaxLength(50)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_admFormasPago_CTEXTOEX01");
             entity.Property(e => e.CTEXTOEXTRA2)
                 .HasMaxLength(50)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_admFormasPago_CTEXTOEX02");
             entity.Property(e => e.CTEXTOEXTRA3)
                 .HasMaxLength(50)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_admFormasPago_CTEXTOEX03");
             entity.Property(e => e.CTIMESTAMP)
                 .HasMaxLength(23)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_admFormasPago_CTIMESTAMP");
+        });
+
+        modelBuilder.Entity<admLigasPago>(entity =>
+        {
+            entity.HasKey(e => e.CIDLIGA);
+
+            entity.HasIndex(e => e.CIDCLIENTEPROVEEDOR, "CIDCLIENTEPROVEEDOR");
+
+            entity.HasIndex(e => e.CIDDOCTOABONO, "CIDDOCTOABONO");
+
+            entity.Property(e => e.CFECHAFINVIG)
+                .HasDefaultValueSql("('18991230')", "DF_admLigasPago_CFECHAFINVIG")
+                .HasColumnType("datetime");
+            entity.Property(e => e.CFECHAINIVIG)
+                .HasDefaultValueSql("('18991230')", "DF_admLigasPago_CFECHAINIVIG")
+                .HasColumnType("datetime");
+            entity.Property(e => e.CFECHAPAGO)
+                .HasDefaultValueSql("('18991230')", "DF_admLigasPago_CFECHAPAGO")
+                .HasColumnType("datetime");
+            entity.Property(e => e.CGUIDEXTERNALREF)
+                .HasMaxLength(40)
+                .IsUnicode(false)
+                .HasDefaultValue("", "DF_admLigasPago_CGUIDEXTERNALREF");
+            entity.Property(e => e.CGUIDLIGA)
+                .HasMaxLength(255)
+                .IsUnicode(false)
+                .HasDefaultValue("", "DF_admLigasPago_CGUIDLIGA");
+            entity.Property(e => e.CLIGA).IsUnicode(false);
         });
 
         modelBuilder.Entity<admMaximosMinimos>(entity =>
@@ -1870,20 +2001,87 @@ public partial class ContpaqiComercialEmpresaDbContext : DbContext
             entity.Property(e => e.CANAQUEL)
                 .HasMaxLength(60)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW10016_CANAQUEL");
             entity.Property(e => e.CIDAUTOINCSQL).ValueGeneratedOnAdd();
             entity.Property(e => e.CPASILLO)
                 .HasMaxLength(60)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW10016_CPASILLO");
             entity.Property(e => e.CREPISA)
                 .HasMaxLength(60)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW10016_CREPISA");
             entity.Property(e => e.CZONA)
                 .HasMaxLength(60)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW10016_CZONA");
+        });
+
+        modelBuilder.Entity<admMensajes>(entity =>
+        {
+            entity.HasKey(e => e.CMESSAGEID);
+
+            entity.HasIndex(e => new { e.CINBOXID, e.CMESSAGEID }, "IINBOXID").IsUnique();
+
+            entity.HasIndex(e => new { e.CINBOXID, e.CSTATUS, e.CQUEUEDAT, e.CMESSAGEID }, "IINBOXSTATUSDATE");
+
+            entity.HasIndex(e => new { e.CSTATUS, e.CQUEUEDAT }, "ISTATUSDATE");
+
+            entity.Property(e => e.CMESSAGEID)
+                .HasMaxLength(40)
+                .IsUnicode(false)
+                .HasDefaultValue("", "DF_admMensajes_CMESSAGEID");
+            entity.Property(e => e.CALIAS)
+                .HasMaxLength(256)
+                .IsUnicode(false)
+                .HasDefaultValue("", "DF_admMensajes_CALIAS");
+            entity.Property(e => e.CBODY).IsUnicode(false);
+            entity.Property(e => e.CCONTENTENCODING)
+                .HasMaxLength(40)
+                .IsUnicode(false)
+                .HasDefaultValue("", "DF_admMensajes_CCONTENTENCODING");
+            entity.Property(e => e.CCONTENTTYPE)
+                .HasMaxLength(40)
+                .IsUnicode(false)
+                .HasDefaultValue("", "DF_admMensajes_CCONTENTTYPE");
+            entity.Property(e => e.CDATOS)
+                .HasMaxLength(100)
+                .IsUnicode(false)
+                .HasDefaultValue("", "DF_admMensajes_CDATOS");
+            entity.Property(e => e.CDUEDATE)
+                .HasDefaultValueSql("('18991230')", "DF_admMensajes_CDUEDATE")
+                .HasColumnType("datetime");
+            entity.Property(e => e.CERROR)
+                .HasMaxLength(254)
+                .IsUnicode(false)
+                .HasDefaultValue("", "DF_admMensajes_CERROR");
+            entity.Property(e => e.CFECHA)
+                .HasDefaultValueSql("('18991230')", "DF_admMensajes_CFECHA")
+                .HasColumnType("datetime");
+            entity.Property(e => e.CHORA)
+                .HasMaxLength(6)
+                .IsUnicode(false)
+                .HasDefaultValue("000000", "DF_admMensajes_CHORA");
+            entity.Property(e => e.CINBOXID)
+                .HasMaxLength(40)
+                .IsUnicode(false)
+                .HasDefaultValue("", "DF_admMensajes_CINBOXID");
+            entity.Property(e => e.CPRIORITY)
+                .HasMaxLength(40)
+                .IsUnicode(false)
+                .HasDefaultValue("", "DF_admMensajes_CPRIORITY");
+            entity.Property(e => e.CPROCESO)
+                .HasMaxLength(100)
+                .IsUnicode(false)
+                .HasDefaultValue("", "DF_admMensajes_CPROCESO");
+            entity.Property(e => e.CQUEUEDAT)
+                .HasDefaultValueSql("('18991230')", "DF_admMensajes_CQUEUEDAT")
+                .HasColumnType("datetime");
+            entity.Property(e => e.CTAGS).IsUnicode(false);
+            entity.Property(e => e.CUSUARIO)
+                .HasMaxLength(15)
+                .IsUnicode(false)
+                .HasDefaultValue("", "DF_admMensajes_CUSUARIO");
         });
 
         modelBuilder.Entity<admMonedas>(entity =>
@@ -1895,31 +2093,31 @@ public partial class ContpaqiComercialEmpresaDbContext : DbContext
             entity.Property(e => e.CCLAVESAT)
                 .HasMaxLength(3)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW10034_CCLAVESAT");
             entity.Property(e => e.CDESCRIPCIONPROTEGIDA)
                 .HasMaxLength(60)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW10034_CDESCRIP01");
             entity.Property(e => e.CNOMBREMONEDA)
                 .HasMaxLength(60)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW10034_CNOMBREM01");
             entity.Property(e => e.CPLURAL)
                 .HasMaxLength(60)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW10034_CPLURAL");
             entity.Property(e => e.CSIMBOLOMONEDA)
                 .HasMaxLength(1)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW10034_CSIMBOLO01");
             entity.Property(e => e.CSINGULAR)
                 .HasMaxLength(60)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW10034_CSINGULAR");
             entity.Property(e => e.CTIMESTAMP)
                 .HasMaxLength(23)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW10034_CTIMESTAMP");
         });
 
         modelBuilder.Entity<admMovimientos>(entity =>
@@ -1961,40 +2159,40 @@ public partial class ContpaqiComercialEmpresaDbContext : DbContext
             entity.HasIndex(e => new { e.CIDPRODUCTO, e.CFECHA, e.CAFECTAEXISTENCIA, e.CIDMOVIMIENTO }, "IPRODUCTOFECHAAFECTA");
 
             entity.Property(e => e.CFECHA)
-                .HasDefaultValueSql("('18991230')")
+                .HasDefaultValueSql("('18991230')", "DF_MGW10010_CFECHA")
                 .HasColumnType("datetime");
             entity.Property(e => e.CFECHAEXTRA)
-                .HasDefaultValueSql("('18991230')")
+                .HasDefaultValueSql("('18991230')", "DF_MGW10010_CFECHAEX01")
                 .HasColumnType("datetime");
             entity.Property(e => e.COBJIMPU01)
                 .HasMaxLength(20)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW10010_COBJIMPU01");
             entity.Property(e => e.COBSERVAMOV).HasColumnType("text");
             entity.Property(e => e.CREFERENCIA)
                 .HasMaxLength(20)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW10010_CREFEREN01");
             entity.Property(e => e.CSCMOVTO)
                 .HasMaxLength(50)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW10010_CSCMOVTO");
             entity.Property(e => e.CTEXTOEXTRA1)
                 .HasMaxLength(50)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW10010_CTEXTOEX01");
             entity.Property(e => e.CTEXTOEXTRA2)
                 .HasMaxLength(50)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW10010_CTEXTOEX02");
             entity.Property(e => e.CTEXTOEXTRA3)
                 .HasMaxLength(50)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW10010_CTEXTOEX03");
             entity.Property(e => e.CTIMESTAMP)
                 .HasMaxLength(23)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW10010_CTIMESTAMP");
         });
 
         modelBuilder.Entity<admMovimientosCapas>(entity =>
@@ -2006,7 +2204,7 @@ public partial class ContpaqiComercialEmpresaDbContext : DbContext
             entity.HasIndex(e => new { e.CIDCAPA, e.CFECHA, e.CIDAUTOINCSQL }, "ICAPAFECHA");
 
             entity.Property(e => e.CFECHA)
-                .HasDefaultValueSql("('18991230')")
+                .HasDefaultValueSql("('18991230')", "DF_MGW10028_CFECHA")
                 .HasColumnType("datetime");
             entity.Property(e => e.CIDAUTOINCSQL).ValueGeneratedOnAdd();
         });
@@ -2020,27 +2218,27 @@ public partial class ContpaqiComercialEmpresaDbContext : DbContext
             entity.Property(e => e.CCONCEPTO)
                 .HasMaxLength(100)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW10024_CCONCEPTO");
             entity.Property(e => e.CCUENTA)
                 .HasMaxLength(250)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW10024_CCUENTA");
             entity.Property(e => e.CDIARIO)
                 .HasMaxLength(10)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW10024_CDIARIO");
             entity.Property(e => e.CREFERENCIA)
                 .HasMaxLength(30)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW10024_CREFEREN01");
             entity.Property(e => e.CSEGNEG)
                 .HasMaxLength(4)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW10024_CSEGNEG");
             entity.Property(e => e.CTIMESTAMP)
                 .HasMaxLength(23)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW10024_CTIMESTAMP");
         });
 
         modelBuilder.Entity<admMovimientosPrepoliza>(entity =>
@@ -2054,26 +2252,26 @@ public partial class ContpaqiComercialEmpresaDbContext : DbContext
             entity.Property(e => e.CONCEPTO)
                 .HasMaxLength(100)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW10039_CONCEPTO");
             entity.Property(e => e.CUENTA)
                 .HasMaxLength(50)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW10039_CUENTA");
             entity.Property(e => e.DIARIO)
                 .HasMaxLength(10)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW10039_DIARIO");
             entity.Property(e => e.FECHA)
-                .HasDefaultValueSql("('18991230')")
+                .HasDefaultValueSql("('18991230')", "DF_MGW10039_FECHA")
                 .HasColumnType("datetime");
             entity.Property(e => e.REFERENCIA)
                 .HasMaxLength(30)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW10039_REFERENCIA");
             entity.Property(e => e.SEGNEG)
                 .HasMaxLength(10)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW10039_SEGNEG");
         });
 
         modelBuilder.Entity<admMovimientosSerie>(entity =>
@@ -2085,7 +2283,7 @@ public partial class ContpaqiComercialEmpresaDbContext : DbContext
             entity.HasIndex(e => new { e.CIDSERIE, e.CFECHA, e.CIDAUTOINCSQL }, "ISERIEFECHA");
 
             entity.Property(e => e.CFECHA)
-                .HasDefaultValueSql("('18991230')")
+                .HasDefaultValueSql("('18991230')", "DF_MGW10036_CFECHA")
                 .HasColumnType("datetime");
             entity.Property(e => e.CIDAUTOINCSQL).ValueGeneratedOnAdd();
         });
@@ -2103,41 +2301,41 @@ public partial class ContpaqiComercialEmpresaDbContext : DbContext
             entity.Property(e => e.CTRANSACTIONID)
                 .HasMaxLength(26)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_admMovtosBancarios_CTRANSACTIONID");
             entity.Property(e => e.CACCOUNTID)
                 .HasMaxLength(26)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_admMovtosBancarios_CACCOUNTID");
             entity.Property(e => e.CDESCRIPCION)
                 .HasMaxLength(256)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_admMovtosBancarios_CDESCRIPCION");
             entity.Property(e => e.CFECHA)
-                .HasDefaultValueSql("('18991230')")
+                .HasDefaultValueSql("('18991230')", "DF_admMovtosBancarios_CFECHA")
                 .HasColumnType("datetime");
             entity.Property(e => e.CFECHAEXTRA)
-                .HasDefaultValueSql("('18991230')")
+                .HasDefaultValueSql("('18991230')", "DF_admMovtosBancarios_CFECHAEX01")
                 .HasColumnType("datetime");
             entity.Property(e => e.CREFERENCIA)
                 .HasMaxLength(128)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_admMovtosBancarios_CREFERENCIA");
             entity.Property(e => e.CTEXTOEXTRA1)
                 .HasMaxLength(50)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_admMovtosBancarios_CTEXTOEX01");
             entity.Property(e => e.CTEXTOEXTRA2)
                 .HasMaxLength(50)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_admMovtosBancarios_CTEXTOEX02");
             entity.Property(e => e.CTEXTOEXTRA3)
                 .HasMaxLength(50)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_admMovtosBancarios_CTEXTOEX03");
             entity.Property(e => e.CTIMESTAMP)
                 .HasMaxLength(23)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_admMovtosBancarios_CTIMESTAMP");
         });
 
         modelBuilder.Entity<admMovtosCEPs>(entity =>
@@ -2151,90 +2349,90 @@ public partial class ContpaqiComercialEmpresaDbContext : DbContext
             entity.Property(e => e.CARCHIVO)
                 .HasMaxLength(256)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_admMovtosCEPs_CARCHIVO");
             entity.Property(e => e.CCADENA).HasColumnType("text");
             entity.Property(e => e.CCERTIFICADO)
                 .HasMaxLength(20)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_admMovtosCEPs_CCERTIFICADO");
             entity.Property(e => e.CCLAVE)
                 .HasMaxLength(12)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_admMovtosCEPs_CCLAVE");
             entity.Property(e => e.CCONCEPTO)
                 .HasMaxLength(60)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_admMovtosCEPs_CCONCEPTO");
             entity.Property(e => e.CEBANCO)
                 .HasMaxLength(60)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_admMovtosCEPs_CEBANCO");
             entity.Property(e => e.CECUENTA)
                 .HasMaxLength(20)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_admMovtosCEPs_CECUENTA");
             entity.Property(e => e.CENOMBRE)
                 .HasMaxLength(60)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_admMovtosCEPs_CENOMBRE");
             entity.Property(e => e.CERFC)
                 .HasMaxLength(20)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_admMovtosCEPs_CERFC");
             entity.Property(e => e.CETIPOCTA)
                 .HasMaxLength(2)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_admMovtosCEPs_CETIPOCTA");
             entity.Property(e => e.CFECHA)
-                .HasDefaultValueSql("('18991230')")
+                .HasDefaultValueSql("('18991230')", "DF_admMovtosCEPs_CFECHA")
                 .HasColumnType("datetime");
             entity.Property(e => e.CFECHAEXTRA)
-                .HasDefaultValueSql("('18991230')")
+                .HasDefaultValueSql("('18991230')", "DF_admMovtosCEPs_CFECHAEX01")
                 .HasColumnType("datetime");
             entity.Property(e => e.CHORA)
                 .HasMaxLength(8)
                 .IsUnicode(false)
-                .HasDefaultValue("00000000");
+                .HasDefaultValue("00000000", "DF_admMovtosCEPs_CHORA");
             entity.Property(e => e.CRBANCO)
                 .HasMaxLength(60)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_admMovtosCEPs_CRBANCO");
             entity.Property(e => e.CRCUENTA)
                 .HasMaxLength(20)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_admMovtosCEPs_CRCUENTA");
             entity.Property(e => e.CRNOMBRE)
                 .HasMaxLength(60)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_admMovtosCEPs_CRNOMBRE");
             entity.Property(e => e.CRRFC)
                 .HasMaxLength(20)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_admMovtosCEPs_CRRFC");
             entity.Property(e => e.CRTIPOCTA)
                 .HasMaxLength(2)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_admMovtosCEPs_CRTIPOCTA");
             entity.Property(e => e.CSELLO)
                 .HasMaxLength(256)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_admMovtosCEPs_CSELLO");
             entity.Property(e => e.CTEXTOEXTRA1)
                 .HasMaxLength(50)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_admMovtosCEPs_CTEXTOEX01");
             entity.Property(e => e.CTEXTOEXTRA2)
                 .HasMaxLength(50)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_admMovtosCEPs_CTEXTOEX02");
             entity.Property(e => e.CTEXTOEXTRA3)
                 .HasMaxLength(50)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_admMovtosCEPs_CTEXTOEX03");
             entity.Property(e => e.CTIMESTAMP)
                 .HasMaxLength(23)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_admMovtosCEPs_CTIMESTAMP");
         });
 
         modelBuilder.Entity<admMovtosInvFisico>(entity =>
@@ -2281,28 +2479,28 @@ public partial class ContpaqiComercialEmpresaDbContext : DbContext
             entity.Property(e => e.CADUANA)
                 .HasMaxLength(60)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW10040_CADUANA");
             entity.Property(e => e.CFECHACADUCIDAD)
-                .HasDefaultValueSql("('18991230')")
+                .HasDefaultValueSql("('18991230')", "DF_MGW10040_CFECHACA01")
                 .HasColumnType("datetime");
             entity.Property(e => e.CFECHAFABRICACION)
-                .HasDefaultValueSql("('18991230')")
+                .HasDefaultValueSql("('18991230')", "DF_MGW10040_CFECHAFA01")
                 .HasColumnType("datetime");
             entity.Property(e => e.CFECHAPEDIMENTO)
-                .HasDefaultValueSql("('18991230')")
+                .HasDefaultValueSql("('18991230')", "DF_MGW10040_CFECHAPE01")
                 .HasColumnType("datetime");
             entity.Property(e => e.CNUMEROLOTE)
                 .HasMaxLength(30)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW10040_CNUMEROL01");
             entity.Property(e => e.CNUMEROSERIE)
                 .HasMaxLength(30)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW10040_CNUMEROS01");
             entity.Property(e => e.CPEDIMENTO)
                 .HasMaxLength(30)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW10040_CPEDIMENTO");
         });
 
         modelBuilder.Entity<admNumerosSerie>(entity =>
@@ -2326,36 +2524,36 @@ public partial class ContpaqiComercialEmpresaDbContext : DbContext
             entity.Property(e => e.CADUANA)
                 .HasMaxLength(60)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW10032_CADUANA");
             entity.Property(e => e.CCLAVESAT)
                 .HasMaxLength(30)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW10032_CCLAVESAT");
             entity.Property(e => e.CFECHACADUCIDAD)
-                .HasDefaultValueSql("('18991230')")
+                .HasDefaultValueSql("('18991230')", "DF_MGW10032_CFECHACA01")
                 .HasColumnType("datetime");
             entity.Property(e => e.CFECHAFABRICACION)
-                .HasDefaultValueSql("('18991230')")
+                .HasDefaultValueSql("('18991230')", "DF_MGW10032_CFECHAFA01")
                 .HasColumnType("datetime");
             entity.Property(e => e.CFECHAPEDIMENTO)
-                .HasDefaultValueSql("('18991230')")
+                .HasDefaultValueSql("('18991230')", "DF_MGW10032_CFECHAPE01")
                 .HasColumnType("datetime");
             entity.Property(e => e.CNUMEROLOTE)
                 .HasMaxLength(30)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW10032_CNUMEROL01");
             entity.Property(e => e.CNUMEROSERIE)
                 .HasMaxLength(30)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW10032_CNUMEROS01");
             entity.Property(e => e.CPEDIMENTO)
                 .HasMaxLength(30)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW10032_CPEDIMENTO");
             entity.Property(e => e.CTIMESTAMP)
                 .HasMaxLength(23)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW10032_CTIMESTAMP");
         });
 
         modelBuilder.Entity<admPagoNotas>(entity =>
@@ -2364,16 +2562,16 @@ public partial class ContpaqiComercialEmpresaDbContext : DbContext
 
             entity.HasIndex(e => new { e.CTIPO, e.CIDDOCUMENTO, e.CIDFORMAPAGO, e.CIDPAGO }, "ITIPODOCTOFORMA");
 
-            entity.Property(e => e.CIDMONEDA).HasDefaultValue(1);
+            entity.Property(e => e.CIDMONEDA).HasDefaultValue(1, "DF_admPagoNotas_CIDMONEDA");
             entity.Property(e => e.CREFERENCIA)
                 .HasMaxLength(100)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_admPagoNotas_CREFERENCIA");
             entity.Property(e => e.CTIMESTAMP)
                 .HasMaxLength(23)
                 .IsUnicode(false)
-                .HasDefaultValue("");
-            entity.Property(e => e.CTIPOCAMBIO).HasDefaultValue(1.0);
+                .HasDefaultValue("", "DF_admPagoNotas_CTIMESTAMP");
+            entity.Property(e => e.CTIPOCAMBIO).HasDefaultValue(1.0, "DF_admPagoNotas_CTIPOCAMBIO");
         });
 
         modelBuilder.Entity<admParametros>(entity =>
@@ -2385,409 +2583,419 @@ public partial class ContpaqiComercialEmpresaDbContext : DbContext
             entity.Property(e => e.CADJUNTO1)
                 .HasMaxLength(253)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW10000_CADJUNTO1");
             entity.Property(e => e.CADJUNTO2)
                 .HasMaxLength(253)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW10000_CADJUNTO2");
             entity.Property(e => e.CASUNTO)
                 .HasMaxLength(253)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW10000_CASUNTO");
             entity.Property(e => e.CAUTRVOE)
                 .HasMaxLength(30)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW10000_CAUTRVOE");
             entity.Property(e => e.CCORREOPRU)
                 .HasMaxLength(253)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW10000_CCORREOPRU");
             entity.Property(e => e.CCUENTAESTATAL)
                 .HasMaxLength(50)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW10000_CCUENTAE01");
             entity.Property(e => e.CCUERPO).HasColumnType("text");
             entity.Property(e => e.CCURPEMPRESA)
                 .HasMaxLength(20)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW10000_CCURPEMP01");
             entity.Property(e => e.CFECAJ2010)
-                .HasDefaultValueSql("('18991230')")
+                .HasDefaultValueSql("('18991230')", "DF_MGW10000_CFECAJ2010")
                 .HasColumnType("datetime");
             entity.Property(e => e.CFECDONAT)
-                .HasDefaultValueSql("('18991230')")
+                .HasDefaultValueSql("('18991230')", "DF_MGW10000_CFECDONAT")
                 .HasColumnType("datetime");
             entity.Property(e => e.CFECHACIERRE)
-                .HasDefaultValueSql("('18991230')")
+                .HasDefaultValueSql("('18991230')", "DF_MGW10000_CFECHACI01")
                 .HasColumnType("datetime");
             entity.Property(e => e.CFECHACONGELAMIENTO)
-                .HasDefaultValueSql("('18991230')")
+                .HasDefaultValueSql("('18991230')", "DF_MGW10000_CFECHACO01")
                 .HasColumnType("datetime");
             entity.Property(e => e.CFIRMA)
                 .HasMaxLength(253)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW10000_CFIRMA");
             entity.Property(e => e.CGUIDDSL)
                 .HasMaxLength(40)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW10000_CGUIDDSL");
             entity.Property(e => e.CGUIDEMPRESA)
                 .HasMaxLength(40)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW10000_CGUIDEMPRESA");
             entity.Property(e => e.CHOST)
                 .HasMaxLength(60)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW10000_CHOST");
             entity.Property(e => e.CHOSTPROXY)
                 .HasMaxLength(253)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW10000_CHOSTPROXY");
             entity.Property(e => e.CHOSTSMTP)
                 .HasMaxLength(60)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW10000_CHOSTSMTP");
+            entity.Property(e => e.CIDPORTALFACT)
+                .HasMaxLength(40)
+                .IsUnicode(false)
+                .HasDefaultValue("", "DF_MGW10000_CIDPORTALFACT");
+            entity.Property(e => e.CINBOXID)
+                .HasMaxLength(40)
+                .IsUnicode(false)
+                .HasDefaultValue("", "DF_MGW10000_CINBOXID");
             entity.Property(e => e.CLEYENDON)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW10000_CLEYENDON");
             entity.Property(e => e.CLEYENDON1)
                 .HasMaxLength(253)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW10000_CLEYENDON1");
             entity.Property(e => e.CLEYENDON2)
                 .HasMaxLength(253)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW10000_CLEYENDON2");
             entity.Property(e => e.CMASCARILLAAGENTE)
                 .HasMaxLength(30)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW10000_CMASCARI04");
             entity.Property(e => e.CMASCARILLAALMACEN)
                 .HasMaxLength(30)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW10000_CMASCARI03");
             entity.Property(e => e.CMASCARILLACLIENTES)
                 .HasMaxLength(30)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW10000_CMASCARI01");
             entity.Property(e => e.CMASCARILLACURP)
                 .HasMaxLength(30)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW10000_CMASCARI06");
             entity.Property(e => e.CMASCARILLAPRODUCTO)
                 .HasMaxLength(30)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW10000_CMASCARI02");
             entity.Property(e => e.CMASCARILLARFC)
                 .HasMaxLength(30)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW10000_CMASCARI05");
             entity.Property(e => e.CMOVFECEX1)
                 .HasMaxLength(20)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW10000_CMOVFECEX1");
             entity.Property(e => e.CMOVIMPEX1)
                 .HasMaxLength(20)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW10000_CMOVIMPEX1");
             entity.Property(e => e.CMOVIMPEX2)
                 .HasMaxLength(20)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW10000_CMOVIMPEX2");
             entity.Property(e => e.CMOVIMPEX3)
                 .HasMaxLength(20)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW10000_CMOVIMPEX3");
             entity.Property(e => e.CMOVIMPEX4)
                 .HasMaxLength(20)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW10000_CMOVIMPEX4");
             entity.Property(e => e.CMOVTEXEX1)
                 .HasMaxLength(20)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW10000_CMOVTEXEX1");
             entity.Property(e => e.CMOVTEXEX2)
                 .HasMaxLength(20)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW10000_CMOVTEXEX2");
             entity.Property(e => e.CMOVTEXEX3)
                 .HasMaxLength(20)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW10000_CMOVTEXEX3");
             entity.Property(e => e.CNOMBRECORTO)
                 .HasMaxLength(20)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW10000_CNOMBREC01");
             entity.Property(e => e.CNOMBREDESCUENTODOC1)
                 .HasMaxLength(20)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW10000_CNOMBRED06");
             entity.Property(e => e.CNOMBREDESCUENTODOC2)
                 .HasMaxLength(20)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW10000_CNOMBRED07");
             entity.Property(e => e.CNOMBREDESCUENTOMOV1)
                 .HasMaxLength(20)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW10000_CNOMBRED01");
             entity.Property(e => e.CNOMBREDESCUENTOMOV2)
                 .HasMaxLength(20)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW10000_CNOMBRED02");
             entity.Property(e => e.CNOMBREDESCUENTOMOV3)
                 .HasMaxLength(20)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW10000_CNOMBRED03");
             entity.Property(e => e.CNOMBREDESCUENTOMOV4)
                 .HasMaxLength(20)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW10000_CNOMBRED04");
             entity.Property(e => e.CNOMBREDESCUENTOMOV5)
                 .HasMaxLength(20)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW10000_CNOMBRED05");
             entity.Property(e => e.CNOMBREEMPRESA)
                 .HasMaxLength(60)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW10000_CNOMBREE01");
             entity.Property(e => e.CNOMBREGASTO1)
                 .HasMaxLength(20)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW10000_CNOMBREG01");
             entity.Property(e => e.CNOMBREGASTO2)
                 .HasMaxLength(20)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW10000_CNOMBREG02");
             entity.Property(e => e.CNOMBREGASTO3)
                 .HasMaxLength(20)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW10000_CNOMBREG03");
             entity.Property(e => e.CNOMBREIMPUESTO1)
                 .HasMaxLength(60)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW10000_CNOMBREI01");
             entity.Property(e => e.CNOMBREIMPUESTO2)
                 .HasMaxLength(60)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW10000_CNOMBREI02");
             entity.Property(e => e.CNOMBREIMPUESTO3)
                 .HasMaxLength(60)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW10000_CNOMBREI03");
             entity.Property(e => e.CNOMBRELISTA1)
                 .HasMaxLength(20)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW10000_CNOMBREL01");
             entity.Property(e => e.CNOMBRELISTA10)
                 .HasMaxLength(20)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW10000_CNOMBREL10");
             entity.Property(e => e.CNOMBRELISTA2)
                 .HasMaxLength(20)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW10000_CNOMBREL02");
             entity.Property(e => e.CNOMBRELISTA3)
                 .HasMaxLength(20)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW10000_CNOMBREL03");
             entity.Property(e => e.CNOMBRELISTA4)
                 .HasMaxLength(20)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW10000_CNOMBREL04");
             entity.Property(e => e.CNOMBRELISTA5)
                 .HasMaxLength(20)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW10000_CNOMBREL05");
             entity.Property(e => e.CNOMBRELISTA6)
                 .HasMaxLength(20)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW10000_CNOMBREL06");
             entity.Property(e => e.CNOMBRELISTA7)
                 .HasMaxLength(20)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW10000_CNOMBREL07");
             entity.Property(e => e.CNOMBRELISTA8)
                 .HasMaxLength(20)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW10000_CNOMBREL08");
             entity.Property(e => e.CNOMBRELISTA9)
                 .HasMaxLength(20)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW10000_CNOMBREL09");
             entity.Property(e => e.CNOMBRERETENCION1)
                 .HasMaxLength(60)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW10000_CNOMBRER01");
             entity.Property(e => e.CNOMBRERETENCION2)
                 .HasMaxLength(60)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW10000_CNOMBRER02");
             entity.Property(e => e.CNUMDONAT)
                 .HasMaxLength(30)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW10000_CNUMDONAT");
+            entity.Property(e => e.CPORTALDIASFACT).HasDefaultValue(1, "DF_MGW10000_CPORTALDIASF");
+            entity.Property(e => e.CPORTALTIPOFACT).HasDefaultValue(1, "DF_MGW10000_CPORTALTIPOFACT");
             entity.Property(e => e.CPROVEEDOROAUTH)
                 .HasMaxLength(30)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW10000_CPROVEEDOROAUTH");
             entity.Property(e => e.CREFRESHTOKENCN)
-                .HasDefaultValueSql("(NULL)")
+                .HasDefaultValueSql("(NULL)", "DF_admParametros_CREFRESHTOKENCN")
                 .HasColumnType("text");
             entity.Property(e => e.CREGIMFISC)
                 .HasMaxLength(253)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW10000_CREGIMFISC");
             entity.Property(e => e.CREGISTROCAMARA)
                 .HasMaxLength(50)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW10000_CREGISTR01");
             entity.Property(e => e.CREPRESENTANTELEGAL)
                 .HasMaxLength(50)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW10000_CREPRESE01");
             entity.Property(e => e.CRFCEMPRESA)
                 .HasMaxLength(20)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW10000_CRFCEMPR01");
             entity.Property(e => e.CRUTACONTPAQ)
                 .HasMaxLength(253)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW10000_CRUTACON01");
             entity.Property(e => e.CRUTAEMPRESAPRED)
                 .HasMaxLength(253)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW10000_CRUTAEMP01");
             entity.Property(e => e.CRUTAENTREGA)
                 .HasMaxLength(253)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW10000_CRUTAENT01");
             entity.Property(e => e.CRUTAPLA01)
                 .HasMaxLength(253)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW10000_CRUTAPLA01");
             entity.Property(e => e.CRUTAPLA02)
                 .HasMaxLength(253)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW10000_CRUTAPLA02");
             entity.Property(e => e.CSEGCIVA10)
                 .HasMaxLength(50)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW10000_CSEGCIVA10");
             entity.Property(e => e.CSEGCIVA11)
                 .HasMaxLength(50)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW10000_CSEGCIVA11");
             entity.Property(e => e.CSEGCIVA15)
                 .HasMaxLength(50)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW10000_CSEGCIVA15");
             entity.Property(e => e.CSEGCIVA16)
                 .HasMaxLength(50)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW10000_CSEGCIVA16");
             entity.Property(e => e.CSEGCIVA8)
                 .HasMaxLength(50)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW10000_CSEGCIVA8");
             entity.Property(e => e.CSEGCIVAOT)
                 .HasMaxLength(50)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW10000_CSEGCIVAOT");
             entity.Property(e => e.CSEGCONTGENERAL1)
                 .HasMaxLength(50)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW10000_CSEGCONT01");
             entity.Property(e => e.CSEGCONTGENERAL10)
                 .HasMaxLength(50)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW10000_CSEGCONT10");
             entity.Property(e => e.CSEGCONTGENERAL11)
                 .HasMaxLength(50)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW10000_CSEGCONT11");
             entity.Property(e => e.CSEGCONTGENERAL2)
                 .HasMaxLength(50)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW10000_CSEGCONT02");
             entity.Property(e => e.CSEGCONTGENERAL3)
                 .HasMaxLength(50)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW10000_CSEGCONT03");
             entity.Property(e => e.CSEGCONTGENERAL4)
                 .HasMaxLength(50)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW10000_CSEGCONT04");
             entity.Property(e => e.CSEGCONTGENERAL5)
                 .HasMaxLength(50)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW10000_CSEGCONT05");
             entity.Property(e => e.CSEGCONTGENERAL6)
                 .HasMaxLength(50)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW10000_CSEGCONT06");
             entity.Property(e => e.CSEGCONTGENERAL7)
                 .HasMaxLength(50)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW10000_CSEGCONT07");
             entity.Property(e => e.CSEGCONTGENERAL8)
                 .HasMaxLength(50)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW10000_CSEGCONT08");
             entity.Property(e => e.CSEGCONTGENERAL9)
                 .HasMaxLength(50)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW10000_CSEGCONT09");
             entity.Property(e => e.CSEGPIVA10)
                 .HasMaxLength(50)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW10000_CSEGPIVA10");
             entity.Property(e => e.CSEGPIVA11)
                 .HasMaxLength(50)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW10000_CSEGPIVA11");
             entity.Property(e => e.CSEGPIVA15)
                 .HasMaxLength(50)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW10000_CSEGPIVA15");
             entity.Property(e => e.CSEGPIVA16)
                 .HasMaxLength(50)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW10000_CSEGPIVA16");
             entity.Property(e => e.CSEGPIVA8)
                 .HasMaxLength(50)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW10000_CSEGPIVA8");
             entity.Property(e => e.CSEGPIVAOT)
                 .HasMaxLength(50)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW10000_CSEGPIVAOT");
             entity.Property(e => e.CTIMESTAMP)
                 .HasMaxLength(23)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW10000_CTIMESTAMP");
             entity.Property(e => e.CTOKENCN)
-                .HasDefaultValueSql("(NULL)")
+                .HasDefaultValueSql("(NULL)", "DF_admParametros_CTOKENCN")
                 .HasColumnType("text");
             entity.Property(e => e.CURLWSTORE)
                 .HasMaxLength(250)
                 .IsUnicode(false)
-                .HasDefaultValueSql("(NULL)");
+                .HasDefaultValueSql("(NULL)", "DF_admParametros_CURLWSTORE");
             entity.Property(e => e.CUSRPROXY)
                 .HasMaxLength(60)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW10000_CUSRPROXY");
             entity.Property(e => e.CVALIDACFD)
                 .HasMaxLength(20)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW10000_CVALIDACFD");
             entity.Property(e => e.CVERPOSI)
                 .HasMaxLength(20)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW10000_CVERPOSI");
             entity.Property(e => e.CVERSIONACTUAL)
                 .HasMaxLength(20)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW10000_CVERSION01");
         });
 
         modelBuilder.Entity<admParametrosBack>(entity =>
@@ -2797,394 +3005,394 @@ public partial class ContpaqiComercialEmpresaDbContext : DbContext
             entity.Property(e => e.CADJUNTO1)
                 .HasMaxLength(253)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_BACK10000_CADJUNTO1");
             entity.Property(e => e.CADJUNTO2)
                 .HasMaxLength(253)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_BACK10000_CADJUNTO2");
             entity.Property(e => e.CASUNTO)
                 .HasMaxLength(253)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_BACK10000_CASUNTO");
             entity.Property(e => e.CAUTRVOE)
                 .HasMaxLength(30)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_BACK10000_CAUTRVOE");
             entity.Property(e => e.CCORREOPRU)
                 .HasMaxLength(253)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_BACK10000_CCORREOPRU");
             entity.Property(e => e.CCUENTAESTATAL)
                 .HasMaxLength(50)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_BACK10000_CCUENTAE01");
             entity.Property(e => e.CCUERPO).HasColumnType("text");
             entity.Property(e => e.CCURPEMPRESA)
                 .HasMaxLength(20)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_BACK10000_CCURPEMP01");
             entity.Property(e => e.CFECAJ2010)
-                .HasDefaultValueSql("('18991230')")
+                .HasDefaultValueSql("('18991230')", "DF_BACK10000_CFECAJ2010")
                 .HasColumnType("datetime");
             entity.Property(e => e.CFECDONAT)
-                .HasDefaultValueSql("('18991230')")
+                .HasDefaultValueSql("('18991230')", "DF_BACK10000_CFECDONAT")
                 .HasColumnType("datetime");
             entity.Property(e => e.CFECHACIERRE)
-                .HasDefaultValueSql("('18991230')")
+                .HasDefaultValueSql("('18991230')", "DF_BACK10000_CFECHACI01")
                 .HasColumnType("datetime");
             entity.Property(e => e.CFECHACONGELAMIENTO)
-                .HasDefaultValueSql("('18991230')")
+                .HasDefaultValueSql("('18991230')", "DF_BACK10000_CFECHACO01")
                 .HasColumnType("datetime");
             entity.Property(e => e.CFIRMA)
                 .HasMaxLength(253)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_BACK10000_CFIRMA");
             entity.Property(e => e.CGUIDDSL)
                 .HasMaxLength(40)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_BACK10000_CGUIDDSL");
             entity.Property(e => e.CGUIDEMPRESA)
                 .HasMaxLength(40)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_BACK10000_CGUIDEMPRESA");
             entity.Property(e => e.CHOST)
                 .HasMaxLength(60)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_BACK10000_CHOST");
             entity.Property(e => e.CHOSTPROXY)
                 .HasMaxLength(253)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_BACK10000_CHOSTPROXY");
             entity.Property(e => e.CHOSTSMTP)
                 .HasMaxLength(60)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_BACK10000_CHOSTSMTP");
             entity.Property(e => e.CLEYENDON1)
                 .HasMaxLength(253)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_BACK10000_CLEYENDON1");
             entity.Property(e => e.CLEYENDON2)
                 .HasMaxLength(253)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_BACK10000_CLEYENDON2");
             entity.Property(e => e.CMASCARILLAAGENTE)
                 .HasMaxLength(30)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_BACK10000_CMASCARI04");
             entity.Property(e => e.CMASCARILLAALMACEN)
                 .HasMaxLength(30)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_BACK10000_CMASCARI03");
             entity.Property(e => e.CMASCARILLACLIENTES)
                 .HasMaxLength(30)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_BACK10000_CMASCARI01");
             entity.Property(e => e.CMASCARILLACURP)
                 .HasMaxLength(30)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_BACK10000_CMASCARI06");
             entity.Property(e => e.CMASCARILLAPRODUCTO)
                 .HasMaxLength(30)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_BACK10000_CMASCARI02");
             entity.Property(e => e.CMASCARILLARFC)
                 .HasMaxLength(30)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_BACK10000_CMASCARI05");
             entity.Property(e => e.CMOVFECEX1)
                 .HasMaxLength(20)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_BACK10000_CMOVFECEX1");
             entity.Property(e => e.CMOVIMPEX1)
                 .HasMaxLength(20)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_BACK10000_CMOVIMPEX1");
             entity.Property(e => e.CMOVIMPEX2)
                 .HasMaxLength(20)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_BACK10000_CMOVIMPEX2");
             entity.Property(e => e.CMOVIMPEX3)
                 .HasMaxLength(20)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_BACK10000_CMOVIMPEX3");
             entity.Property(e => e.CMOVIMPEX4)
                 .HasMaxLength(20)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_BACK10000_CMOVIMPEX4");
             entity.Property(e => e.CMOVTEXEX1)
                 .HasMaxLength(20)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_BACK10000_CMOVTEXEX1");
             entity.Property(e => e.CMOVTEXEX2)
                 .HasMaxLength(20)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_BACK10000_CMOVTEXEX2");
             entity.Property(e => e.CMOVTEXEX3)
                 .HasMaxLength(20)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_BACK10000_CMOVTEXEX3");
             entity.Property(e => e.CNOMBRECORTO)
                 .HasMaxLength(20)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_BACK10000_CNOMBREC01");
             entity.Property(e => e.CNOMBREDESCUENTODOC1)
                 .HasMaxLength(20)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_BACK10000_CNOMBRED06");
             entity.Property(e => e.CNOMBREDESCUENTODOC2)
                 .HasMaxLength(20)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_BACK10000_CNOMBRED07");
             entity.Property(e => e.CNOMBREDESCUENTOMOV1)
                 .HasMaxLength(20)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_BACK10000_CNOMBRED01");
             entity.Property(e => e.CNOMBREDESCUENTOMOV2)
                 .HasMaxLength(20)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_BACK10000_CNOMBRED02");
             entity.Property(e => e.CNOMBREDESCUENTOMOV3)
                 .HasMaxLength(20)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_BACK10000_CNOMBRED03");
             entity.Property(e => e.CNOMBREDESCUENTOMOV4)
                 .HasMaxLength(20)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_BACK10000_CNOMBRED04");
             entity.Property(e => e.CNOMBREDESCUENTOMOV5)
                 .HasMaxLength(20)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_BACK10000_CNOMBRED05");
             entity.Property(e => e.CNOMBREEMPRESA)
                 .HasMaxLength(60)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_BACK10000_CNOMBREE01");
             entity.Property(e => e.CNOMBREGASTO1)
                 .HasMaxLength(20)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_BACK10000_CNOMBREG01");
             entity.Property(e => e.CNOMBREGASTO2)
                 .HasMaxLength(20)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_BACK10000_CNOMBREG02");
             entity.Property(e => e.CNOMBREGASTO3)
                 .HasMaxLength(20)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_BACK10000_CNOMBREG03");
             entity.Property(e => e.CNOMBREIMPUESTO1)
                 .HasMaxLength(60)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_BACK10000_CNOMBREI01");
             entity.Property(e => e.CNOMBREIMPUESTO2)
                 .HasMaxLength(60)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_BACK10000_CNOMBREI02");
             entity.Property(e => e.CNOMBREIMPUESTO3)
                 .HasMaxLength(60)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_BACK10000_CNOMBREI03");
             entity.Property(e => e.CNOMBRELISTA1)
                 .HasMaxLength(20)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_BACK10000_CNOMBREL01");
             entity.Property(e => e.CNOMBRELISTA10)
                 .HasMaxLength(20)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_BACK10000_CNOMBREL10");
             entity.Property(e => e.CNOMBRELISTA2)
                 .HasMaxLength(20)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_BACK10000_CNOMBREL02");
             entity.Property(e => e.CNOMBRELISTA3)
                 .HasMaxLength(20)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_BACK10000_CNOMBREL03");
             entity.Property(e => e.CNOMBRELISTA4)
                 .HasMaxLength(20)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_BACK10000_CNOMBREL04");
             entity.Property(e => e.CNOMBRELISTA5)
                 .HasMaxLength(20)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_BACK10000_CNOMBREL05");
             entity.Property(e => e.CNOMBRELISTA6)
                 .HasMaxLength(20)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_BACK10000_CNOMBREL06");
             entity.Property(e => e.CNOMBRELISTA7)
                 .HasMaxLength(20)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_BACK10000_CNOMBREL07");
             entity.Property(e => e.CNOMBRELISTA8)
                 .HasMaxLength(20)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_BACK10000_CNOMBREL08");
             entity.Property(e => e.CNOMBRELISTA9)
                 .HasMaxLength(20)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_BACK10000_CNOMBREL09");
             entity.Property(e => e.CNOMBRERETENCION1)
                 .HasMaxLength(60)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_BACK10000_CNOMBRER01");
             entity.Property(e => e.CNOMBRERETENCION2)
                 .HasMaxLength(60)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_BACK10000_CNOMBRER02");
             entity.Property(e => e.CNUMDONAT)
                 .HasMaxLength(30)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_BACK10000_CNUMDONAT");
             entity.Property(e => e.CREFRESHTOKENCN)
-                .HasDefaultValueSql("(NULL)")
+                .HasDefaultValueSql("(NULL)", "DF_admParametrosBack_CREFRESHTOKENCN")
                 .HasColumnType("text");
             entity.Property(e => e.CREGIMFISC)
                 .HasMaxLength(253)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_BACK10000_CREGIMFISC");
             entity.Property(e => e.CREGISTROCAMARA)
                 .HasMaxLength(50)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_BACK10000_CREGISTR01");
             entity.Property(e => e.CREPRESENTANTELEGAL)
                 .HasMaxLength(50)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_BACK10000_CREPRESE01");
             entity.Property(e => e.CRFCEMPRESA)
                 .HasMaxLength(20)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_BACK10000_CRFCEMPR01");
             entity.Property(e => e.CRUTACONTPAQ)
                 .HasMaxLength(253)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_BACK10000_CRUTACON01");
             entity.Property(e => e.CRUTAEMPRESAPRED)
                 .HasMaxLength(253)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_BACK10000_CRUTAEMP01");
             entity.Property(e => e.CRUTAENTREGA)
                 .HasMaxLength(253)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_BACK10000_CRUTAENT01");
             entity.Property(e => e.CRUTAPLA01)
                 .HasMaxLength(253)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_BACK10000_CRUTAPLA01");
             entity.Property(e => e.CRUTAPLA02)
                 .HasMaxLength(253)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_BACK10000_CRUTAPLA02");
             entity.Property(e => e.CSEGCIVA10)
                 .HasMaxLength(50)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_BACK10000_CSEGCIVA10");
             entity.Property(e => e.CSEGCIVA11)
                 .HasMaxLength(50)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_BACK10000_CSEGCIVA11");
             entity.Property(e => e.CSEGCIVA15)
                 .HasMaxLength(50)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_BACK10000_CSEGCIVA15");
             entity.Property(e => e.CSEGCIVA16)
                 .HasMaxLength(50)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_BACK10000_CSEGCIVA16");
             entity.Property(e => e.CSEGCIVAOT)
                 .HasMaxLength(50)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_BACK10000_CSEGCIVAOT");
             entity.Property(e => e.CSEGCONTGENERAL1)
                 .HasMaxLength(50)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_BACK10000_CSEGCONT01");
             entity.Property(e => e.CSEGCONTGENERAL10)
                 .HasMaxLength(50)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_BACK10000_CSEGCONT10");
             entity.Property(e => e.CSEGCONTGENERAL11)
                 .HasMaxLength(50)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_BACK10000_CSEGCONT11");
             entity.Property(e => e.CSEGCONTGENERAL2)
                 .HasMaxLength(50)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_BACK10000_CSEGCONT02");
             entity.Property(e => e.CSEGCONTGENERAL3)
                 .HasMaxLength(50)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_BACK10000_CSEGCONT03");
             entity.Property(e => e.CSEGCONTGENERAL4)
                 .HasMaxLength(50)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_BACK10000_CSEGCONT04");
             entity.Property(e => e.CSEGCONTGENERAL5)
                 .HasMaxLength(50)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_BACK10000_CSEGCONT05");
             entity.Property(e => e.CSEGCONTGENERAL6)
                 .HasMaxLength(50)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_BACK10000_CSEGCONT06");
             entity.Property(e => e.CSEGCONTGENERAL7)
                 .HasMaxLength(50)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_BACK10000_CSEGCONT07");
             entity.Property(e => e.CSEGCONTGENERAL8)
                 .HasMaxLength(50)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_BACK10000_CSEGCONT08");
             entity.Property(e => e.CSEGCONTGENERAL9)
                 .HasMaxLength(50)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_BACK10000_CSEGCONT09");
             entity.Property(e => e.CSEGPIVA10)
                 .HasMaxLength(50)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_BACK10000_CSEGPIVA10");
             entity.Property(e => e.CSEGPIVA11)
                 .HasMaxLength(50)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_BACK10000_CSEGPIVA11");
             entity.Property(e => e.CSEGPIVA15)
                 .HasMaxLength(50)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_BACK10000_CSEGPIVA15");
             entity.Property(e => e.CSEGPIVA16)
                 .HasMaxLength(50)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_BACK10000_CSEGPIVA16");
             entity.Property(e => e.CSEGPIVAOT)
                 .HasMaxLength(50)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_BACK10000_CSEGPIVAOT");
             entity.Property(e => e.CTIMESTAMP)
                 .HasMaxLength(23)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_BACK10000_CTIMESTAMP");
             entity.Property(e => e.CTOKENCN)
-                .HasDefaultValueSql("(NULL)")
+                .HasDefaultValueSql("(NULL)", "DF_admParametrosBack_CTOKENCN")
                 .HasColumnType("text");
             entity.Property(e => e.CURLWSTORE)
                 .HasMaxLength(250)
                 .IsUnicode(false)
-                .HasDefaultValueSql("(NULL)");
+                .HasDefaultValueSql("(NULL)", "DF_admParametrosBack_CURLWSTORE");
             entity.Property(e => e.CUSRPROXY)
                 .HasMaxLength(60)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_BACK10000_CUSRPROXY");
             entity.Property(e => e.CVALIDACFD)
                 .HasMaxLength(20)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_BACK10000_CVALIDACFD");
             entity.Property(e => e.CVERPOSI)
                 .HasMaxLength(20)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_BACK10000_CVERPOSI");
             entity.Property(e => e.CVERSIONACTUAL)
                 .HasMaxLength(20)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_BACK10000_CVERSION01");
         });
 
         modelBuilder.Entity<admPreciosCompra>(entity =>
@@ -3200,12 +3408,12 @@ public partial class ContpaqiComercialEmpresaDbContext : DbContext
             entity.Property(e => e.CCODIGOPRODUCTOPROVEEDOR)
                 .HasMaxLength(20)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW10014_CCODIGOP01");
             entity.Property(e => e.CIDAUTOINCSQL).ValueGeneratedOnAdd();
             entity.Property(e => e.CTIMESTAMP)
                 .HasMaxLength(23)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW10014_CTIMESTAMP");
         });
 
         modelBuilder.Entity<admPrepolizas>(entity =>
@@ -3226,21 +3434,21 @@ public partial class ContpaqiComercialEmpresaDbContext : DbContext
             entity.Property(e => e.CHORA)
                 .HasMaxLength(8)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW10038_CHORA");
             entity.Property(e => e.CIDTRANSACCION)
                 .HasMaxLength(50)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW10038_CIDTRANSACCION");
             entity.Property(e => e.CONCEPTO)
                 .HasMaxLength(50)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW10038_CONCEPTO");
             entity.Property(e => e.DIARIO)
                 .HasMaxLength(10)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW10038_DIARIO");
             entity.Property(e => e.FECHA)
-                .HasDefaultValueSql("('18991230')")
+                .HasDefaultValueSql("('18991230')", "DF_MGW10038_FECHA")
                 .HasColumnType("datetime");
         });
 
@@ -3297,104 +3505,104 @@ public partial class ContpaqiComercialEmpresaDbContext : DbContext
             entity.Property(e => e.CCLAVESAT)
                 .HasMaxLength(8)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW10005_CCLAVESAT");
             entity.Property(e => e.CCODALTERN)
                 .HasMaxLength(30)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW10005_CCODALTERN");
             entity.Property(e => e.CCODIGOPRODUCTO)
                 .HasMaxLength(30)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW10005_CCODIGOP01");
             entity.Property(e => e.CCTAPRED)
                 .HasMaxLength(150)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW10005_CCTAPRED");
             entity.Property(e => e.CDESCCORTA)
                 .HasMaxLength(30)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW10005_CDESCCORTA");
             entity.Property(e => e.CDESCRIPCIONPRODUCTO).HasColumnType("text");
             entity.Property(e => e.CFECCOSEX1)
-                .HasDefaultValueSql("('18991230')")
+                .HasDefaultValueSql("('18991230')", "DF_MGW10005_CFECCOSEX1")
                 .HasColumnType("datetime");
             entity.Property(e => e.CFECCOSEX2)
-                .HasDefaultValueSql("('18991230')")
+                .HasDefaultValueSql("('18991230')", "DF_MGW10005_CFECCOSEX2")
                 .HasColumnType("datetime");
             entity.Property(e => e.CFECCOSEX3)
-                .HasDefaultValueSql("('18991230')")
+                .HasDefaultValueSql("('18991230')", "DF_MGW10005_CFECCOSEX3")
                 .HasColumnType("datetime");
             entity.Property(e => e.CFECCOSEX4)
-                .HasDefaultValueSql("('18991230')")
+                .HasDefaultValueSql("('18991230')", "DF_MGW10005_CFECCOSEX4")
                 .HasColumnType("datetime");
             entity.Property(e => e.CFECCOSEX5)
-                .HasDefaultValueSql("('18991230')")
+                .HasDefaultValueSql("('18991230')", "DF_MGW10005_CFECCOSEX5")
                 .HasColumnType("datetime");
             entity.Property(e => e.CFECHAALTAPRODUCTO)
-                .HasDefaultValueSql("('18991230')")
+                .HasDefaultValueSql("('18991230')", "DF_MGW10005_CFECHAAL01")
                 .HasColumnType("datetime");
             entity.Property(e => e.CFECHABAJA)
-                .HasDefaultValueSql("('18991230')")
+                .HasDefaultValueSql("('18991230')", "DF_MGW10005_CFECHABAJA")
                 .HasColumnType("datetime");
             entity.Property(e => e.CFECHAERRORCOSTO)
-                .HasDefaultValueSql("('18991230')")
+                .HasDefaultValueSql("('18991230')", "DF_MGW10005_CFECHAER01")
                 .HasColumnType("datetime");
             entity.Property(e => e.CFECHAEXTRA)
-                .HasDefaultValueSql("('18991230')")
+                .HasDefaultValueSql("('18991230')", "DF_MGW10005_CFECHAEX01")
                 .HasColumnType("datetime");
             entity.Property(e => e.CNOMALTERN)
                 .HasMaxLength(60)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW10005_CNOMALTERN");
             entity.Property(e => e.CNOMBREPRODUCTO)
                 .HasMaxLength(60)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW10005_CNOMBREP01");
             entity.Property(e => e.CSEGCONTPRODUCTO1)
                 .HasMaxLength(50)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW10005_CSEGCONT01");
             entity.Property(e => e.CSEGCONTPRODUCTO2)
                 .HasMaxLength(50)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW10005_CSEGCONT02");
             entity.Property(e => e.CSEGCONTPRODUCTO3)
                 .HasMaxLength(50)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW10005_CSEGCONT03");
             entity.Property(e => e.CSEGCONTPRODUCTO4)
                 .HasMaxLength(20)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW10005_CSEGCONT04");
             entity.Property(e => e.CSEGCONTPRODUCTO5)
                 .HasMaxLength(20)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW10005_CSEGCONT05");
             entity.Property(e => e.CSEGCONTPRODUCTO6)
                 .HasMaxLength(20)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW10005_CSEGCONT06");
             entity.Property(e => e.CSEGCONTPRODUCTO7)
                 .HasMaxLength(20)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW10005_CSEGCONT07");
             entity.Property(e => e.CTEXTOEXTRA1)
                 .HasMaxLength(50)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW10005_CTEXTOEX01");
             entity.Property(e => e.CTEXTOEXTRA2)
                 .HasMaxLength(50)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW10005_CTEXTOEX02");
             entity.Property(e => e.CTEXTOEXTRA3)
                 .HasMaxLength(50)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW10005_CTEXTOEX03");
             entity.Property(e => e.CTIMESTAMP)
                 .HasMaxLength(23)
                 .IsUnicode(false)
-                .HasDefaultValue("");
-            entity.Property(e => e.CUNIDADDIMENSION).HasDefaultValue(-1);
+                .HasDefaultValue("", "DF_MGW10005_CTIMESTAMP");
+            entity.Property(e => e.CUNIDADDIMENSION).HasDefaultValue(-1, "DF_MGW10005_CUNIDADDIMENSION");
         });
 
         modelBuilder.Entity<admProductosDetalles>(entity =>
@@ -3414,7 +3622,7 @@ public partial class ContpaqiComercialEmpresaDbContext : DbContext
             entity.Property(e => e.CTIMESTAMP)
                 .HasMaxLength(23)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW10004_CTIMESTAMP");
         });
 
         modelBuilder.Entity<admProductosFotos>(entity =>
@@ -3427,7 +3635,7 @@ public partial class ContpaqiComercialEmpresaDbContext : DbContext
             entity.Property(e => e.CNOMBREFOTOPRODUCTO)
                 .HasMaxLength(40)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_IMG10001_CNOMBREF01");
         });
 
         modelBuilder.Entity<admPromociones>(entity =>
@@ -3447,32 +3655,32 @@ public partial class ContpaqiComercialEmpresaDbContext : DbContext
             entity.Property(e => e.CCODIGOPROMOCION)
                 .HasMaxLength(30)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW10029_CCODIGOP01");
             entity.Property(e => e.CFECHAALTA)
-                .HasDefaultValueSql("('18991230')")
+                .HasDefaultValueSql("('18991230')", "DF_MGW10029_CFECHAALTA")
                 .HasColumnType("datetime");
             entity.Property(e => e.CFECHAFIN)
-                .HasDefaultValueSql("('18991230')")
+                .HasDefaultValueSql("('18991230')", "DF_MGW10029_CFECHAFIN")
                 .HasColumnType("datetime");
             entity.Property(e => e.CFECHAINICIO)
-                .HasDefaultValueSql("('18991230')")
+                .HasDefaultValueSql("('18991230')", "DF_MGW10029_CFECHAIN01")
                 .HasColumnType("datetime");
             entity.Property(e => e.CHORAFIN)
                 .HasMaxLength(4)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW10029_CHORAFIN");
             entity.Property(e => e.CHORAINI)
                 .HasMaxLength(4)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW10029_CHORAINI");
             entity.Property(e => e.CNOMBREPROMOCION)
                 .HasMaxLength(60)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW10029_CNOMBREP01");
             entity.Property(e => e.CTIMESTAMP)
                 .HasMaxLength(23)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW10029_CTIMESTAMP");
         });
 
         modelBuilder.Entity<admProyectos>(entity =>
@@ -3500,48 +3708,48 @@ public partial class ContpaqiComercialEmpresaDbContext : DbContext
             entity.Property(e => e.CCODIGOPROYECTO)
                 .HasMaxLength(30)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_admProyectos_CCODIGOPROYECTO");
             entity.Property(e => e.CFECHAALTA)
-                .HasDefaultValueSql("('18991230')")
+                .HasDefaultValueSql("('18991230')", "DF_admProyectos_CFECHAALTA")
                 .HasColumnType("datetime");
             entity.Property(e => e.CFECHABAJA)
-                .HasDefaultValueSql("('18991230')")
+                .HasDefaultValueSql("('18991230')", "DF_admProyectos_CFECHABAJA")
                 .HasColumnType("datetime");
             entity.Property(e => e.CFECHAEXTRA)
-                .HasDefaultValueSql("('18991230')")
+                .HasDefaultValueSql("('18991230')", "DF_admProyectos_CFECHAEX01")
                 .HasColumnType("datetime");
             entity.Property(e => e.CNOMBREPROYECTO)
                 .HasMaxLength(60)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_admProyectos_CNOMBREPROYECTO");
             entity.Property(e => e.CSEGCONT1)
                 .HasMaxLength(50)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_admProyectos_CSEGCONT1");
             entity.Property(e => e.CSEGCONT2)
                 .HasMaxLength(50)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_admProyectos_CSEGCONT2");
             entity.Property(e => e.CSEGCONT3)
                 .HasMaxLength(50)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_admProyectos_CSEGCONT3");
             entity.Property(e => e.CTEXTOEXTRA1)
                 .HasMaxLength(50)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_admProyectos_CTEXTOEX01");
             entity.Property(e => e.CTEXTOEXTRA2)
                 .HasMaxLength(50)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_admProyectos_CTEXTOEX02");
             entity.Property(e => e.CTEXTOEXTRA3)
                 .HasMaxLength(50)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_admProyectos_CTEXTOEX03");
             entity.Property(e => e.CTIMESTAMP)
                 .HasMaxLength(23)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_admProyectos_CTIMESTAMP");
         });
 
         modelBuilder.Entity<admSATSegmentos>(entity =>
@@ -3553,23 +3761,47 @@ public partial class ContpaqiComercialEmpresaDbContext : DbContext
             entity.Property(e => e.CCLAVE)
                 .HasMaxLength(10)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_admSATSegmentos_CCLAVE");
             entity.Property(e => e.CDESCRIPCION)
                 .HasMaxLength(152)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_admSATSegmentos_CDESCRIPCION");
             entity.Property(e => e.CSEGCONT1)
                 .HasMaxLength(50)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_admSATSegmentos_CSEGCONT1");
             entity.Property(e => e.CSEGCONT2)
                 .HasMaxLength(50)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_admSATSegmentos_CSEGCONT2");
             entity.Property(e => e.CSEGCONT3)
                 .HasMaxLength(50)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_admSATSegmentos_CSEGCONT3");
+        });
+
+        modelBuilder.Entity<admSegmentosImpuestos>(entity =>
+        {
+            entity.HasKey(e => e.CIDSEGMENTO);
+
+            entity.HasIndex(e => new { e.CTIPO, e.CCATALOGO, e.CIDSEGMENTO }, "ITIPOCATALOGO");
+
+            entity.Property(e => e.CSEGMENTO1)
+                .HasMaxLength(50)
+                .IsUnicode(false)
+                .HasDefaultValue("", "DF_admSegmentosImpuestos_CSEGMENTO1");
+            entity.Property(e => e.CSEGMENTO2)
+                .HasMaxLength(50)
+                .IsUnicode(false)
+                .HasDefaultValue("", "DF_admSegmentosImpuestos_CSEGMENTO2");
+            entity.Property(e => e.CSEGMENTO3)
+                .HasMaxLength(50)
+                .IsUnicode(false)
+                .HasDefaultValue("", "DF_admSegmentosImpuestos_CSEGMENTO3");
+            entity.Property(e => e.CTIMESTAMP)
+                .HasMaxLength(23)
+                .IsUnicode(false)
+                .HasDefaultValue("", "DF_admSegmentosImpuestos_CTIMESTAMP");
         });
 
         modelBuilder.Entity<admTiposCambio>(entity =>
@@ -3581,12 +3813,12 @@ public partial class ContpaqiComercialEmpresaDbContext : DbContext
             entity.HasIndex(e => new { e.CIDMONEDA, e.CFECHA }, "IMONEDAFECHADESC");
 
             entity.Property(e => e.CFECHA)
-                .HasDefaultValueSql("('18991230')")
+                .HasDefaultValueSql("('18991230')", "DF_MGW10035_CFECHA")
                 .HasColumnType("datetime");
             entity.Property(e => e.CTIMESTAMP)
                 .HasMaxLength(23)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW10035_CTIMESTAMP");
         });
 
         modelBuilder.Entity<admUnidadesMedidaPeso>(entity =>
@@ -3600,23 +3832,23 @@ public partial class ContpaqiComercialEmpresaDbContext : DbContext
             entity.Property(e => e.CABREVIATURA)
                 .HasMaxLength(3)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW10026_CABREVIA01");
             entity.Property(e => e.CCLAVEINT)
                 .HasMaxLength(3)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW10026_CCLAVEINT");
             entity.Property(e => e.CCLAVESAT)
                 .HasMaxLength(3)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW10026_CCLAVESAT");
             entity.Property(e => e.CDESPLIEGUE)
                 .HasMaxLength(3)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW10026_CDESPLIE01");
             entity.Property(e => e.CNOMBREUNIDAD)
                 .HasMaxLength(60)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW10026_CNOMBREU01");
         });
 
         modelBuilder.Entity<admVistasCampos>(entity =>
@@ -3630,16 +3862,16 @@ public partial class ContpaqiComercialEmpresaDbContext : DbContext
             entity.Property(e => e.CNOMBRENATIVOTABLA)
                 .HasMaxLength(9)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_CAC00007_CNOMBREN01");
             entity.Property(e => e.CNOMBRENATIVOCAMPO)
                 .HasMaxLength(51)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_CAC00007_CNOMBREN02");
             entity.Property(e => e.CIDAUTOINCSQL).ValueGeneratedOnAdd();
             entity.Property(e => e.CNOMBREAMIGABLECAMPO)
                 .HasMaxLength(51)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_CAC00007_CNOMBREA01");
         });
 
         modelBuilder.Entity<admVistasConsultas>(entity =>
@@ -3651,15 +3883,15 @@ public partial class ContpaqiComercialEmpresaDbContext : DbContext
             entity.Property(e => e.CFILTROS)
                 .HasMaxLength(128)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_CAC00005_CFILTROS");
             entity.Property(e => e.CINDICE)
                 .HasMaxLength(26)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_CAC00005_CINDICE");
             entity.Property(e => e.CNOMBRECONSULTA)
                 .HasMaxLength(51)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_CAC00005_CNOMBREC01");
             entity.Property(e => e.CSENTENCIASQL).HasColumnType("text");
         });
 
@@ -3671,7 +3903,7 @@ public partial class ContpaqiComercialEmpresaDbContext : DbContext
             entity.Property(e => e.CNOMBREMODULO)
                 .HasMaxLength(51)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_CAC00008_CNOMBREM01");
         });
 
         modelBuilder.Entity<admVistasRecursos>(entity =>
@@ -3681,48 +3913,48 @@ public partial class ContpaqiComercialEmpresaDbContext : DbContext
             entity.Property(e => e.CTABLABASE)
                 .HasMaxLength(9)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_CAC00004_CTABLABASE");
             entity.Property(e => e.CCAMPOBASE)
                 .HasMaxLength(26)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_CAC00004_CCAMPOBASE");
             entity.Property(e => e.CCAMPO0)
                 .HasMaxLength(26)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_CAC00004_CCAMPO0");
             entity.Property(e => e.CCAMPO1)
                 .HasMaxLength(26)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_CAC00004_CCAMPO1");
             entity.Property(e => e.CCAMPOID)
                 .HasMaxLength(26)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_CAC00004_CCAMPOID");
             entity.Property(e => e.CIDAUTOINCSQL).ValueGeneratedOnAdd();
             entity.Property(e => e.CINDICE0)
                 .HasMaxLength(26)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_CAC00004_CINDICE0");
             entity.Property(e => e.CINDICE1)
                 .HasMaxLength(26)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_CAC00004_CINDICE1");
             entity.Property(e => e.CRANGO)
                 .HasMaxLength(51)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_CAC00004_CRANGO");
             entity.Property(e => e.CTABLARELA)
                 .HasMaxLength(9)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_CAC00004_CTABLARELA");
             entity.Property(e => e.CTITULO0)
                 .HasMaxLength(41)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_CAC00004_CTITULO0");
             entity.Property(e => e.CTITULO1)
                 .HasMaxLength(41)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_CAC00004_CTITULO1");
         });
 
         modelBuilder.Entity<admVistasRelaciones>(entity =>
@@ -3738,39 +3970,39 @@ public partial class ContpaqiComercialEmpresaDbContext : DbContext
             entity.Property(e => e.CCAMPONA01)
                 .HasMaxLength(51)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_CAC00009_CCAMPONA01");
             entity.Property(e => e.CFILTRO)
                 .HasMaxLength(254)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_CAC00009_CFILTRO");
             entity.Property(e => e.CFILTROAUX)
                 .HasMaxLength(80)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_CAC00009_CFILTROAUX");
             entity.Property(e => e.CNOMBRENATIVOTABLA1)
                 .HasMaxLength(9)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_CAC00009_CNOMBREN01");
             entity.Property(e => e.CNOMBRENATIVOTABLA2)
                 .HasMaxLength(9)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_CAC00009_CNOMBREN02");
             entity.Property(e => e.CNOMBRERELACION)
                 .HasMaxLength(51)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_CAC00009_CNOMBRER01");
             entity.Property(e => e.CSENTENCIAENLACE)
                 .HasMaxLength(127)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_CAC00009_CSENTENC01");
             entity.Property(e => e.CTABLAREL1)
                 .HasMaxLength(9)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_CAC00009_CTABLAREL1");
             entity.Property(e => e.CTABLAREL2)
                 .HasMaxLength(9)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_CAC00009_CTABLAREL2");
         });
 
         modelBuilder.Entity<admVistasTablas>(entity =>
@@ -3782,16 +4014,16 @@ public partial class ContpaqiComercialEmpresaDbContext : DbContext
             entity.Property(e => e.CNOMBRENATIVOTABLA)
                 .HasMaxLength(9)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_CAC00006_CNOMBREN01");
             entity.Property(e => e.CIDAUTOINCSQL).ValueGeneratedOnAdd();
             entity.Property(e => e.CINDICES)
                 .HasMaxLength(128)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_CAC00006_CINDICES");
             entity.Property(e => e.CNOMBREAMIGABLETABLA)
                 .HasMaxLength(51)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_CAC00006_CNOMBREA01");
         });
 
         modelBuilder.Entity<nubeCuentas>(entity =>
@@ -3801,23 +4033,23 @@ public partial class ContpaqiComercialEmpresaDbContext : DbContext
             entity.Property(e => e.CCUENTA)
                 .HasMaxLength(50)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_nubeCuentas_CCUENTA");
             entity.Property(e => e.CMONEDA)
                 .HasMaxLength(3)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_nubeCuentas_CMONEDA");
             entity.Property(e => e.CNOMBRE)
                 .HasMaxLength(255)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_nubeCuentas_CNOMBRE");
             entity.Property(e => e.CSEGMENTO)
                 .HasMaxLength(10)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_nubeCuentas_CSEGMENTO");
             entity.Property(e => e.CTIPO)
                 .HasMaxLength(3)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_nubeCuentas_CTIPO");
         });
 
         modelBuilder.Entity<nubeDiarios>(entity =>
@@ -3827,11 +4059,11 @@ public partial class ContpaqiComercialEmpresaDbContext : DbContext
             entity.Property(e => e.CCODIGO)
                 .HasMaxLength(12)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_nubeDiarios_CCUENTA");
             entity.Property(e => e.CNOMBRE)
                 .HasMaxLength(255)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_nubeDiarios_CNOMBRE");
         });
 
         OnModelCreatingPartial(modelBuilder);

--- a/src/ARSoftware.Contpaqi.Comercial.Sql/Contexts/ContpaqiComercialEmpresaDbContext.cs
+++ b/src/ARSoftware.Contpaqi.Comercial.Sql/Contexts/ContpaqiComercialEmpresaDbContext.cs
@@ -20,6 +20,8 @@ public partial class ContpaqiComercialEmpresaDbContext : DbContext
 
     public virtual DbSet<admAlmacenes> admAlmacenes { get; set; }
 
+    public virtual DbSet<admAperturas> admAperturas { get; set; }
+
     public virtual DbSet<admAsientosContables> admAsientosContables { get; set; }
 
     public virtual DbSet<admAsocAcumConceptos> admAsocAcumConceptos { get; set; }
@@ -31,6 +33,8 @@ public partial class ContpaqiComercialEmpresaDbContext : DbContext
     public virtual DbSet<admBanderas> admBanderas { get; set; }
 
     public virtual DbSet<admBitacoras> admBitacoras { get; set; }
+
+    public virtual DbSet<admCajas> admCajas { get; set; }
 
     public virtual DbSet<admCapasProducto> admCapasProducto { get; set; }
 
@@ -72,6 +76,8 @@ public partial class ContpaqiComercialEmpresaDbContext : DbContext
 
     public virtual DbSet<admFoliosDigitales> admFoliosDigitales { get; set; }
 
+    public virtual DbSet<admFormasPago> admFormasPago { get; set; }
+
     public virtual DbSet<admMaximosMinimos> admMaximosMinimos { get; set; }
 
     public virtual DbSet<admMonedas> admMonedas { get; set; }
@@ -95,6 +101,8 @@ public partial class ContpaqiComercialEmpresaDbContext : DbContext
     public virtual DbSet<admMovtosInvFisicoSerieCa> admMovtosInvFisicoSerieCa { get; set; }
 
     public virtual DbSet<admNumerosSerie> admNumerosSerie { get; set; }
+
+    public virtual DbSet<admPagoNotas> admPagoNotas { get; set; }
 
     public virtual DbSet<admParametros> admParametros { get; set; }
 
@@ -302,6 +310,45 @@ public partial class ContpaqiComercialEmpresaDbContext : DbContext
                 .HasDefaultValue("");
         });
 
+        modelBuilder.Entity<admAperturas>(entity =>
+        {
+            entity.HasKey(e => e.CIDAPERTURA);
+
+            entity.HasIndex(e => new { e.CFECHAAPERTURA, e.CIDAPERTURA }, "CFECHAAPERTURA");
+
+            entity.HasIndex(e => new { e.CIDCAJA, e.CIDAPERTURA }, "CIDCAJA");
+
+            entity.Property(e => e.CFECHAAPERTURA)
+                .HasDefaultValueSql("('18991230')")
+                .HasColumnType("datetime");
+            entity.Property(e => e.CFECHACORTE)
+                .HasDefaultValueSql("('18991230')")
+                .HasColumnType("datetime");
+            entity.Property(e => e.CFECHAFACTURA)
+                .HasDefaultValueSql("('18991230')")
+                .HasColumnType("datetime");
+            entity.Property(e => e.CHORAAPERTURA)
+                .HasMaxLength(6)
+                .IsUnicode(false)
+                .HasDefaultValue("000000");
+            entity.Property(e => e.CHORACORTE)
+                .HasMaxLength(6)
+                .IsUnicode(false)
+                .HasDefaultValue("000000");
+            entity.Property(e => e.CTERMINAL)
+                .HasMaxLength(30)
+                .IsUnicode(false)
+                .HasDefaultValue("");
+            entity.Property(e => e.CTIMESTAMP)
+                .HasMaxLength(23)
+                .IsUnicode(false)
+                .HasDefaultValue("");
+            entity.Property(e => e.CUSUARIO)
+                .HasMaxLength(15)
+                .IsUnicode(false)
+                .HasDefaultValue("");
+        });
+
         modelBuilder.Entity<admAsientosContables>(entity =>
         {
             entity.HasKey(e => e.CIDASIENTOCONTABLE);
@@ -357,6 +404,10 @@ public partial class ContpaqiComercialEmpresaDbContext : DbContext
         {
             entity.HasKey(e => new { e.CIDDOCUMENTOABONO, e.CIDDOCUMENTOCARGO, e.CTEXTOTASA });
 
+            entity.HasIndex(e => new { e.CIDDOCUMENTOABONO, e.CESDETALLE }, "IABONODET");
+
+            entity.HasIndex(e => new { e.CIDDOCUMENTOCARGO, e.CESDETALLE }, "ICARGODET");
+
             entity.HasIndex(e => new { e.CIDDOCUMENTOCARGO, e.CIDDOCUMENTOABONO, e.CTEXTOTASA }, "IDOCTOCARGOABONO").IsUnique();
 
             entity.Property(e => e.CTEXTOTASA)
@@ -365,6 +416,14 @@ public partial class ContpaqiComercialEmpresaDbContext : DbContext
             entity.Property(e => e.CIDAUTOINCSQL).ValueGeneratedOnAdd();
             entity.Property(e => e.CMETODOPAG)
                 .HasMaxLength(100)
+                .IsUnicode(false)
+                .HasDefaultValue("");
+            entity.Property(e => e.CNOMIMPLOC)
+                .HasMaxLength(60)
+                .IsUnicode(false)
+                .HasDefaultValue("");
+            entity.Property(e => e.COBJIMPU01)
+                .HasMaxLength(20)
                 .IsUnicode(false)
                 .HasDefaultValue("");
         });
@@ -446,6 +505,73 @@ public partial class ContpaqiComercialEmpresaDbContext : DbContext
                 .HasDefaultValue("");
             entity.Property(e => e.USUARIO2)
                 .HasMaxLength(15)
+                .IsUnicode(false)
+                .HasDefaultValue("");
+        });
+
+        modelBuilder.Entity<admCajas>(entity =>
+        {
+            entity.HasKey(e => e.CIDCAJA);
+
+            entity.HasIndex(e => e.CCODIGOCAJA, "CCODIGOCAJA").IsUnique();
+
+            entity.HasIndex(e => new { e.CFECHAALTA, e.CIDCAJA }, "CFECHAALTA");
+
+            entity.HasIndex(e => new { e.CIDVALORCLASIFICACION1, e.CIDCAJA }, "CIDVALORCLASIFICACION1");
+
+            entity.HasIndex(e => e.CNOMBRECAJA, "CNOMBRECAJA").IsUnique();
+
+            entity.Property(e => e.CCODIGOCAJA)
+                .HasMaxLength(30)
+                .IsUnicode(false)
+                .HasDefaultValue("");
+            entity.Property(e => e.CFECHAALTA)
+                .HasDefaultValueSql("('18991230')")
+                .HasColumnType("datetime");
+            entity.Property(e => e.CFECHABAJA)
+                .HasDefaultValueSql("('18991230')")
+                .HasColumnType("datetime");
+            entity.Property(e => e.CFECHAEXTRA)
+                .HasDefaultValueSql("('18991230')")
+                .HasColumnType("datetime");
+            entity.Property(e => e.CNOMBRECAJA)
+                .HasMaxLength(60)
+                .IsUnicode(false)
+                .HasDefaultValue("");
+            entity.Property(e => e.CSERIEDEVN)
+                .HasMaxLength(11)
+                .IsUnicode(false)
+                .HasDefaultValue("");
+            entity.Property(e => e.CSERIENOTA)
+                .HasMaxLength(11)
+                .IsUnicode(false)
+                .HasDefaultValue("");
+            entity.Property(e => e.CTEXTOEXTRA1)
+                .HasMaxLength(50)
+                .IsUnicode(false)
+                .HasDefaultValue("");
+            entity.Property(e => e.CTEXTOEXTRA2)
+                .HasMaxLength(50)
+                .IsUnicode(false)
+                .HasDefaultValue("");
+            entity.Property(e => e.CTEXTOEXTRA3)
+                .HasMaxLength(50)
+                .IsUnicode(false)
+                .HasDefaultValue("");
+            entity.Property(e => e.CTIMESTAMP)
+                .HasMaxLength(23)
+                .IsUnicode(false)
+                .HasDefaultValue("");
+            entity.Property(e => e.cReporteApertura)
+                .HasMaxLength(60)
+                .IsUnicode(false)
+                .HasDefaultValue("");
+            entity.Property(e => e.cReporteCorte)
+                .HasMaxLength(60)
+                .IsUnicode(false)
+                .HasDefaultValue("");
+            entity.Property(e => e.cReporteNota)
+                .HasMaxLength(60)
                 .IsUnicode(false)
                 .HasDefaultValue("");
         });
@@ -818,6 +944,10 @@ public partial class ContpaqiComercialEmpresaDbContext : DbContext
                 .HasMaxLength(60)
                 .IsUnicode(false)
                 .HasDefaultValue("");
+            entity.Property(e => e.CWHATSAPP)
+                .HasMaxLength(15)
+                .IsUnicode(false)
+                .HasDefaultValue("");
         });
 
         modelBuilder.Entity<admComponentesPaquete>(entity =>
@@ -1143,6 +1273,8 @@ public partial class ContpaqiComercialEmpresaDbContext : DbContext
 
             entity.HasIndex(e => new { e.CFECHAVENCIMIENTO, e.CIDDOCUMENTO }, "CFECHAVENCIMIENTO");
 
+            entity.HasIndex(e => new { e.CIDAPERTURA, e.CIDDOCUMENTO }, "CIDAPERTURA");
+
             entity.HasIndex(e => new { e.CIDCOPIADE, e.CFECHA, e.CIDDOCUMENTO }, "CIDCOPIADE");
 
             entity.HasIndex(e => new { e.CIDCUENTA, e.CFECHA, e.CIDDOCUMENTO }, "CIDCUENTA");
@@ -1199,6 +1331,7 @@ public partial class ContpaqiComercialEmpresaDbContext : DbContext
                 .HasMaxLength(120)
                 .IsUnicode(false)
                 .HasDefaultValue("");
+            entity.Property(e => e.CDATOSADICIONALES).IsUnicode(false);
             entity.Property(e => e.CDESTINATARIO)
                 .HasMaxLength(60)
                 .IsUnicode(false)
@@ -1672,6 +1805,56 @@ public partial class ContpaqiComercialEmpresaDbContext : DbContext
                 .HasDefaultValue("");
             entity.Property(e => e.CUUID)
                 .HasMaxLength(60)
+                .IsUnicode(false)
+                .HasDefaultValue("");
+        });
+
+        modelBuilder.Entity<admFormasPago>(entity =>
+        {
+            entity.HasKey(e => e.CIDFORMAPAGO);
+
+            entity.HasIndex(e => e.CCODIGOFORMAPAGO, "CCODIGOFORMA").IsUnique();
+
+            entity.HasIndex(e => new { e.CFECHAALTA, e.CIDFORMAPAGO }, "CFECHAALTA");
+
+            entity.HasIndex(e => e.CNOMBREFORMAPAGO, "CNOMBREFORMAPAGO").IsUnique();
+
+            entity.Property(e => e.CCLAVESAT)
+                .HasMaxLength(3)
+                .IsUnicode(false)
+                .HasDefaultValue("");
+            entity.Property(e => e.CCODIGOFORMAPAGO)
+                .HasMaxLength(30)
+                .IsUnicode(false)
+                .HasDefaultValue("");
+            entity.Property(e => e.CFECHAALTA)
+                .HasDefaultValueSql("('18991230')")
+                .HasColumnType("datetime");
+            entity.Property(e => e.CFECHABAJA)
+                .HasDefaultValueSql("('18991230')")
+                .HasColumnType("datetime");
+            entity.Property(e => e.CFECHAEXTRA)
+                .HasDefaultValueSql("('18991230')")
+                .HasColumnType("datetime");
+            entity.Property(e => e.CIDMONEDA).HasDefaultValue(1);
+            entity.Property(e => e.CNOMBREFORMAPAGO)
+                .HasMaxLength(60)
+                .IsUnicode(false)
+                .HasDefaultValue("");
+            entity.Property(e => e.CTEXTOEXTRA1)
+                .HasMaxLength(50)
+                .IsUnicode(false)
+                .HasDefaultValue("");
+            entity.Property(e => e.CTEXTOEXTRA2)
+                .HasMaxLength(50)
+                .IsUnicode(false)
+                .HasDefaultValue("");
+            entity.Property(e => e.CTEXTOEXTRA3)
+                .HasMaxLength(50)
+                .IsUnicode(false)
+                .HasDefaultValue("");
+            entity.Property(e => e.CTIMESTAMP)
+                .HasMaxLength(23)
                 .IsUnicode(false)
                 .HasDefaultValue("");
         });
@@ -2175,6 +2358,24 @@ public partial class ContpaqiComercialEmpresaDbContext : DbContext
                 .HasDefaultValue("");
         });
 
+        modelBuilder.Entity<admPagoNotas>(entity =>
+        {
+            entity.HasKey(e => e.CIDPAGO);
+
+            entity.HasIndex(e => new { e.CTIPO, e.CIDDOCUMENTO, e.CIDFORMAPAGO, e.CIDPAGO }, "ITIPODOCTOFORMA");
+
+            entity.Property(e => e.CIDMONEDA).HasDefaultValue(1);
+            entity.Property(e => e.CREFERENCIA)
+                .HasMaxLength(100)
+                .IsUnicode(false)
+                .HasDefaultValue("");
+            entity.Property(e => e.CTIMESTAMP)
+                .HasMaxLength(23)
+                .IsUnicode(false)
+                .HasDefaultValue("");
+            entity.Property(e => e.CTIPOCAMBIO).HasDefaultValue(1.0);
+        });
+
         modelBuilder.Entity<admParametros>(entity =>
         {
             entity.HasKey(e => e.CIDEMPRESA);
@@ -2422,6 +2623,10 @@ public partial class ContpaqiComercialEmpresaDbContext : DbContext
                 .IsUnicode(false)
                 .HasDefaultValue("");
             entity.Property(e => e.CNUMDONAT)
+                .HasMaxLength(30)
+                .IsUnicode(false)
+                .HasDefaultValue("");
+            entity.Property(e => e.CPROVEEDOROAUTH)
                 .HasMaxLength(30)
                 .IsUnicode(false)
                 .HasDefaultValue("");
@@ -3189,6 +3394,7 @@ public partial class ContpaqiComercialEmpresaDbContext : DbContext
                 .HasMaxLength(23)
                 .IsUnicode(false)
                 .HasDefaultValue("");
+            entity.Property(e => e.CUNIDADDIMENSION).HasDefaultValue(-1);
         });
 
         modelBuilder.Entity<admProductosDetalles>(entity =>
@@ -3538,7 +3744,7 @@ public partial class ContpaqiComercialEmpresaDbContext : DbContext
                 .IsUnicode(false)
                 .HasDefaultValue("");
             entity.Property(e => e.CFILTROAUX)
-                .HasMaxLength(53)
+                .HasMaxLength(80)
                 .IsUnicode(false)
                 .HasDefaultValue("");
             entity.Property(e => e.CNOMBRENATIVOTABLA1)

--- a/src/ARSoftware.Contpaqi.Comercial.Sql/Contexts/ContpaqiComercialGeneralesDbContext.cs
+++ b/src/ARSoftware.Contpaqi.Comercial.Sql/Contexts/ContpaqiComercialGeneralesDbContext.cs
@@ -46,6 +46,8 @@ public partial class ContpaqiComercialGeneralesDbContext : DbContext
 
     public virtual DbSet<ParametrosInicialesMto> ParametrosInicialesMto { get; set; }
 
+    public virtual DbSet<ProveedoresNube> ProveedoresNube { get; set; }
+
     public virtual DbSet<SATBancos> SATBancos { get; set; }
 
     public virtual DbSet<SATClaveProdServ> SATClaveProdServ { get; set; }
@@ -87,12 +89,12 @@ public partial class ContpaqiComercialGeneralesDbContext : DbContext
             entity.HasIndex(e => new { e.CTIPODOCTO, e.CVERSION, e.CIDESQUEMA }, "ITIPOVER");
 
             entity.Property(e => e.CFECHAFIN)
-                .HasDefaultValueSql("('18991230')")
+                .HasDefaultValueSql("('18991230')", "DF_MGW00009_CFECHAFIN")
                 .HasColumnType("datetime");
             entity.Property(e => e.CVERSION)
                 .HasMaxLength(6)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW00009_CVERSION");
         });
 
         modelBuilder.Entity<CAC00003>(entity =>
@@ -111,16 +113,16 @@ public partial class ContpaqiComercialGeneralesDbContext : DbContext
             entity.Property(e => e.TABLA)
                 .HasMaxLength(25)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_CAC0000C_TABLA");
             entity.Property(e => e.CORTO)
                 .HasMaxLength(10)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_CAC0000C_CORTO");
             entity.Property(e => e.CIDAUTOINCSQL).ValueGeneratedOnAdd();
             entity.Property(e => e.LARGO)
                 .HasMaxLength(25)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_CAC0000C_LARGO");
         });
 
         modelBuilder.Entity<CAC0000I>(entity =>
@@ -132,16 +134,16 @@ public partial class ContpaqiComercialGeneralesDbContext : DbContext
             entity.Property(e => e.TABLA)
                 .HasMaxLength(25)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_CAC0000I_TABLA");
             entity.Property(e => e.CORTO)
                 .HasMaxLength(10)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_CAC0000I_CORTO");
             entity.Property(e => e.CIDAUTOINCSQL).ValueGeneratedOnAdd();
             entity.Property(e => e.LARGO)
                 .HasMaxLength(25)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_CAC0000I_LARGO");
         });
 
         modelBuilder.Entity<CACIdiom>(entity =>
@@ -151,24 +153,24 @@ public partial class ContpaqiComercialGeneralesDbContext : DbContext
             entity.Property(e => e.ARCHAYUDA)
                 .HasMaxLength(25)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_CACIdiom_ARCHAYUDA");
             entity.Property(e => e.ARCHBDD)
                 .HasMaxLength(25)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_CACIdiom_ARCHBDD");
             entity.Property(e => e.CIDAUTOINCSQL).ValueGeneratedOnAdd();
             entity.Property(e => e.NOMBREDLLAPP)
                 .HasMaxLength(20)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_CACIdiom_NOMBREDL01");
             entity.Property(e => e.NOMBREDLLERR)
                 .HasMaxLength(20)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_CACIdiom_NOMBREDL02");
             entity.Property(e => e.NOMBREIDIOMA)
                 .HasMaxLength(60)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_CACIdiom_NOMBREID01");
         });
 
         modelBuilder.Entity<ControlProcesos>(entity =>
@@ -200,15 +202,15 @@ public partial class ContpaqiComercialGeneralesDbContext : DbContext
             entity.Property(e => e.CNOMBREEMPRESA)
                 .HasMaxLength(150)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW00001_CNOMBREE01");
             entity.Property(e => e.CRUTADATOS)
                 .HasMaxLength(253)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW00001_CRUTADATOS");
             entity.Property(e => e.CRUTARESPALDOS)
                 .HasMaxLength(253)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW00001_CRUTARES01");
         });
 
         modelBuilder.Entity<EmpresasModelo>(entity =>
@@ -220,11 +222,11 @@ public partial class ContpaqiComercialGeneralesDbContext : DbContext
             entity.Property(e => e.CNOMBREEMPRESA)
                 .HasMaxLength(150)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_CAC00001_CNOMBREE01");
             entity.Property(e => e.CRUTAARCHIVOS)
                 .HasMaxLength(253)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_CAC00001_CRUTAARC01");
         });
 
         modelBuilder.Entity<Etiquetas>(entity =>
@@ -238,123 +240,123 @@ public partial class ContpaqiComercialGeneralesDbContext : DbContext
             entity.Property(e => e.CFUENTEADUANA)
                 .HasMaxLength(30)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW00005_CFUENTEA01");
             entity.Property(e => e.CFUENTECARACTERISTICA1)
                 .HasMaxLength(30)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW00005_CFUENTEC01");
             entity.Property(e => e.CFUENTECARACTERISTICA2)
                 .HasMaxLength(30)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW00005_CFUENTEC02");
             entity.Property(e => e.CFUENTECARACTERISTICA3)
                 .HasMaxLength(30)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW00005_CFUENTEC03");
             entity.Property(e => e.CFUENTEFECHACADUCIDAD)
                 .HasMaxLength(30)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW00005_CFUENTEF01");
             entity.Property(e => e.CFUENTEFECHAFABRICACION)
                 .HasMaxLength(30)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW00005_CFUENTEF02");
             entity.Property(e => e.CFUENTEFECHAPEDIMENTO)
                 .HasMaxLength(30)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW00005_CFUENTEF03");
             entity.Property(e => e.CFUENTEIMPUESTO)
                 .HasMaxLength(30)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW00005_CFUENTEI01");
             entity.Property(e => e.CFUENTENOMBREPRODUCTO)
                 .HasMaxLength(30)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW00005_CFUENTEN01");
             entity.Property(e => e.CFUENTENUMEROLOTE)
                 .HasMaxLength(30)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW00005_CFUENTEN02");
             entity.Property(e => e.CFUENTEPEDIMENTO)
                 .HasMaxLength(30)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW00005_CFUENTEP02");
             entity.Property(e => e.CFUENTEPRECIOPRODUCTO)
                 .HasMaxLength(30)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW00005_CFUENTEP01");
             entity.Property(e => e.CFUENTESERIE)
                 .HasMaxLength(30)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW00005_CFUENTES01");
             entity.Property(e => e.CFUENTETIPOCAMBIO)
                 .HasMaxLength(30)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW00005_CFUENTET01");
             entity.Property(e => e.CNOMBREETIQUETA)
                 .HasMaxLength(30)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW00005_CNOMBREE01");
             entity.Property(e => e.CSUPLEMENTO)
                 .HasMaxLength(5)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW00005_CSUPLEME01");
             entity.Property(e => e.CTEXTOADUANA)
                 .HasMaxLength(30)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW00005_CTEXTOAD01");
             entity.Property(e => e.CTEXTOCARACTERISTICA1)
                 .HasMaxLength(30)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW00005_CTEXTOCA01");
             entity.Property(e => e.CTEXTOCARACTERISTICA2)
                 .HasMaxLength(30)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW00005_CTEXTOCA02");
             entity.Property(e => e.CTEXTOCARACTERISTICA3)
                 .HasMaxLength(30)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW00005_CTEXTOCA03");
             entity.Property(e => e.CTEXTOFECHACADUCIDAD)
                 .HasMaxLength(30)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW00005_CTEXTOFE01");
             entity.Property(e => e.CTEXTOFECHAFABRICACION)
                 .HasMaxLength(30)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW00005_CTEXTOFE02");
             entity.Property(e => e.CTEXTOFECHAPEDIMENTO)
                 .HasMaxLength(30)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW00005_CTEXTOFE03");
             entity.Property(e => e.CTEXTOIMPUESTO)
                 .HasMaxLength(30)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW00005_CTEXTOIM01");
             entity.Property(e => e.CTEXTONOMBREPRODUCTO)
                 .HasMaxLength(30)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW00005_CTEXTONO01");
             entity.Property(e => e.CTEXTONUMEROLOTE)
                 .HasMaxLength(30)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW00005_CTEXTONU01");
             entity.Property(e => e.CTEXTOPEDIMENTO)
                 .HasMaxLength(30)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW00005_CTEXTOPE01");
             entity.Property(e => e.CTEXTOPRECIOPRODUCTO)
                 .HasMaxLength(30)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW00005_CTEXTOPR01");
             entity.Property(e => e.CTEXTOSERIE)
                 .HasMaxLength(30)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW00005_CTEXTOSE01");
             entity.Property(e => e.CTEXTOTIPOCAMBIO)
                 .HasMaxLength(30)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW00005_CTEXTOTI01");
         });
 
         modelBuilder.Entity<FormatosEtiquetas>(entity =>
@@ -366,7 +368,7 @@ public partial class ContpaqiComercialGeneralesDbContext : DbContext
             entity.Property(e => e.CNOMBREHOJA)
                 .HasMaxLength(30)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW00006_CNOMBREH01");
         });
 
         modelBuilder.Entity<Formulas>(entity =>
@@ -378,12 +380,12 @@ public partial class ContpaqiComercialGeneralesDbContext : DbContext
             entity.Property(e => e.CDESCRIPCION)
                 .HasMaxLength(150)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW00002_CDESCRIP01");
             entity.Property(e => e.CDESCRIPCIONEJEMPLO).HasColumnType("text");
             entity.Property(e => e.CNOMBRE)
                 .HasMaxLength(50)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW00002_CNOMBRE");
         });
 
         modelBuilder.Entity<IdxAdminPAQ>(entity =>
@@ -393,24 +395,24 @@ public partial class ContpaqiComercialGeneralesDbContext : DbContext
             entity.Property(e => e.TABLA)
                 .HasMaxLength(25)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_IdxAdminPAQ_TABLA");
             entity.Property(e => e.NOMBRE)
                 .HasMaxLength(50)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_IdxAdminPAQ_NOMBRE");
             entity.Property(e => e.TIPO)
                 .HasMaxLength(1)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_IdxAdminPAQ_TIPO");
             entity.Property(e => e.GRUPO)
                 .HasMaxLength(1)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_IdxAdminPAQ_GRUPO");
             entity.Property(e => e.CIDAUTOINCSQL).ValueGeneratedOnAdd();
             entity.Property(e => e.DESCRIPCIO)
                 .HasMaxLength(253)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_IdxAdminPAQ_DESCRIPCIO");
         });
 
         modelBuilder.Entity<MantenimientoBDDErrores>(entity =>
@@ -460,11 +462,11 @@ public partial class ContpaqiComercialGeneralesDbContext : DbContext
             entity.Property(e => e.CDESCRIPCION)
                 .HasMaxLength(60)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_CAC00010_CDESCRIP01");
             entity.Property(e => e.CRUTA)
                 .HasMaxLength(253)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_CAC00010_CRUTA");
         });
 
         modelBuilder.Entity<ParametrosInicialesMto>(entity =>
@@ -476,6 +478,20 @@ public partial class ContpaqiComercialGeneralesDbContext : DbContext
                 .IsUnicode(false);
         });
 
+        modelBuilder.Entity<ProveedoresNube>(entity =>
+        {
+            entity.HasKey(e => e.CIDPROVEEDORSERVICIO);
+
+            entity.Property(e => e.CNOMBREPROVEEDOR)
+                .HasMaxLength(150)
+                .IsUnicode(false)
+                .HasDefaultValue("", "DF_ProveedoresNube_CNOMBREPROVEEDOR");
+            entity.Property(e => e.CURLBASE)
+                .HasMaxLength(255)
+                .IsUnicode(false)
+                .HasDefaultValue("", "DF_ProveedoresNube_CURLBASE");
+        });
+
         modelBuilder.Entity<SATBancos>(entity =>
         {
             entity.HasKey(e => e.CCLAVE);
@@ -485,23 +501,23 @@ public partial class ContpaqiComercialGeneralesDbContext : DbContext
             entity.Property(e => e.CCLAVE)
                 .HasMaxLength(3)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_SATBancos_CCLAVE");
             entity.Property(e => e.CDESCRIPCION)
                 .HasMaxLength(150)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_SATBancos_CDESCRIPCION");
             entity.Property(e => e.CNOMBRE)
                 .HasMaxLength(40)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_SATBancos_CNOMBRE");
             entity.Property(e => e.CPAGINAWEB)
                 .HasMaxLength(250)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_SATBancos_CPAGINAWEB");
             entity.Property(e => e.CRFC)
                 .HasMaxLength(20)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_SATBancos_CRFC");
         });
 
         modelBuilder.Entity<SATClaveProdServ>(entity =>
@@ -511,12 +527,12 @@ public partial class ContpaqiComercialGeneralesDbContext : DbContext
             entity.Property(e => e.CCLAVE)
                 .HasMaxLength(10)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_SATClaveProdServ_CCLAVE");
             entity.Property(e => e.CDESCRIPCION)
                 .HasMaxLength(152)
                 .IsUnicode(false)
-                .HasDefaultValue("");
-            entity.Property(e => e.CESTATUS).HasDefaultValue(1);
+                .HasDefaultValue("", "DF_SATClaveProdServ_CDESCRIPCION");
+            entity.Property(e => e.CESTATUS).HasDefaultValue(1, "DF_SATClaveProdServ_CESTATUS");
         });
 
         modelBuilder.Entity<SATEstaciones>(entity =>
@@ -528,23 +544,23 @@ public partial class ContpaqiComercialGeneralesDbContext : DbContext
             entity.Property(e => e.CTIPO)
                 .HasMaxLength(2)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_SATEstaciones_CTIPO");
             entity.Property(e => e.CCLAVE)
                 .HasMaxLength(16)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_SATEstaciones_CCLAVE");
             entity.Property(e => e.CDESCRIPCION)
                 .HasMaxLength(100)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_SATEstaciones_CDESCRIPCION");
             entity.Property(e => e.CEXTRA)
                 .HasMaxLength(20)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_SATEstaciones_CEXTRA");
             entity.Property(e => e.CNACIONALIDAD)
                 .HasMaxLength(30)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_SATEstaciones_CNACIONALIDAD");
         });
 
         modelBuilder.Entity<SATFracciones>(entity =>
@@ -566,12 +582,12 @@ public partial class ContpaqiComercialGeneralesDbContext : DbContext
             entity.Property(e => e.CCODIGO)
                 .HasMaxLength(3)
                 .IsUnicode(false)
-                .HasDefaultValue("");
-            entity.Property(e => e.CDECIMALES).HasDefaultValue(2);
+                .HasDefaultValue("", "DF_SATMonedas_CCODIGO");
+            entity.Property(e => e.CDECIMALES).HasDefaultValue(2, "DF_SATMonedas_CDECIMALES");
             entity.Property(e => e.CNOMBRE)
                 .HasMaxLength(100)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_SATMonedas_CNOMBRE");
         });
 
         modelBuilder.Entity<SATUnidades>(entity =>
@@ -581,15 +597,15 @@ public partial class ContpaqiComercialGeneralesDbContext : DbContext
             entity.Property(e => e.CCLAVE)
                 .HasMaxLength(3)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_SATUnidades_CCLAVE");
             entity.Property(e => e.CDESCRIPCION)
                 .HasMaxLength(512)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_SATUnidades_CDESCRIPCION");
             entity.Property(e => e.CNOMBRE)
                 .HasMaxLength(100)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_SATUnidades_CNOMBRE");
         });
 
         modelBuilder.Entity<UsuariosActivos>(entity =>
@@ -599,11 +615,11 @@ public partial class ContpaqiComercialGeneralesDbContext : DbContext
             entity.Property(e => e.CEMPRESA)
                 .HasMaxLength(150)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW00007_CEMPRESA");
             entity.Property(e => e.CUSUARIO)
                 .HasMaxLength(30)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW00007_CUSUARIO");
         });
 
         modelBuilder.Entity<UsuariosActivosBloqueos>(entity =>
@@ -613,11 +629,11 @@ public partial class ContpaqiComercialGeneralesDbContext : DbContext
             entity.Property(e => e.CEMPRESA)
                 .HasMaxLength(150)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW00007B_CEMPRESA");
             entity.Property(e => e.CUSUARIO)
                 .HasMaxLength(30)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_MGW00007B_CUSUARIO");
         });
 
         modelBuilder.Entity<admVistasCampos>(entity =>
@@ -629,16 +645,16 @@ public partial class ContpaqiComercialGeneralesDbContext : DbContext
             entity.Property(e => e.CNOMBRENATIVOTABLA)
                 .HasMaxLength(9)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_CAC00007_CNOMBREN01");
             entity.Property(e => e.CNOMBRENATIVOCAMPO)
                 .HasMaxLength(51)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_CAC00007_CNOMBREN02");
             entity.Property(e => e.CIDAUTOINCSQL).ValueGeneratedOnAdd();
             entity.Property(e => e.CNOMBREAMIGABLECAMPO)
                 .HasMaxLength(51)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_CAC00007_CNOMBREA01");
         });
 
         modelBuilder.Entity<admVistasConsultas>(entity =>
@@ -650,7 +666,7 @@ public partial class ContpaqiComercialGeneralesDbContext : DbContext
             entity.Property(e => e.CNOMBRECONSULTA)
                 .HasMaxLength(51)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_CAC00005_CNOMBREC01");
             entity.Property(e => e.CSENTENCIASQL).HasColumnType("text");
         });
 
@@ -662,7 +678,7 @@ public partial class ContpaqiComercialGeneralesDbContext : DbContext
             entity.Property(e => e.CNOMBREMODULO)
                 .HasMaxLength(51)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_CAC00008_CNOMBREM01");
         });
 
         modelBuilder.Entity<admVistasRelaciones>(entity =>
@@ -678,19 +694,19 @@ public partial class ContpaqiComercialGeneralesDbContext : DbContext
             entity.Property(e => e.CNOMBRENATIVOTABLA1)
                 .HasMaxLength(9)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_CAC00009_CNOMBREN01");
             entity.Property(e => e.CNOMBRENATIVOTABLA2)
                 .HasMaxLength(9)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_CAC00009_CNOMBREN02");
             entity.Property(e => e.CNOMBRERELACION)
                 .HasMaxLength(51)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_CAC00009_CNOMBRER01");
             entity.Property(e => e.CSENTENCIAENLACE)
                 .HasMaxLength(201)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_CAC00009_CSENTENC01");
         });
 
         modelBuilder.Entity<admVistasTablas>(entity =>
@@ -702,12 +718,12 @@ public partial class ContpaqiComercialGeneralesDbContext : DbContext
             entity.Property(e => e.CNOMBRENATIVOTABLA)
                 .HasMaxLength(9)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_CAC00006_CNOMBREN01");
             entity.Property(e => e.CIDAUTOINCSQL).ValueGeneratedOnAdd();
             entity.Property(e => e.CNOMBREAMIGABLETABLA)
                 .HasMaxLength(51)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_CAC00006_CNOMBREA01");
         });
 
         modelBuilder.Entity<nubeEmpresas>(entity =>
@@ -719,23 +735,23 @@ public partial class ContpaqiComercialGeneralesDbContext : DbContext
             entity.Property(e => e.CIDEMPRESA)
                 .HasMaxLength(253)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_nubeEmpresas_CIDEMPRESA");
             entity.Property(e => e.CEMPRESA)
                 .HasMaxLength(253)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_nubeEmpresas_CEMPRESA");
             entity.Property(e => e.CPROPIETARIO)
                 .HasMaxLength(150)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_nubeEmpresas_CPROPIETARIO");
             entity.Property(e => e.CRFC)
                 .HasMaxLength(20)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_nubeEmpresas_CRFC");
             entity.Property(e => e.CTIPO)
                 .HasMaxLength(20)
                 .IsUnicode(false)
-                .HasDefaultValue("");
+                .HasDefaultValue("", "DF_nubeEmpresas_CTIPO");
         });
 
         OnModelCreatingPartial(modelBuilder);

--- a/src/Sql.MigrationsStartupProject/Sql.MigrationsStartupProject.csproj
+++ b/src/Sql.MigrationsStartupProject/Sql.MigrationsStartupProject.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <ImplicitUsings>disable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/src/Sql.MigrationsStartupProject/Sql.MigrationsStartupProject.csproj
+++ b/src/Sql.MigrationsStartupProject/Sql.MigrationsStartupProject.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>disable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/src/Sql.MigrationsStartupProject/Sql.MigrationsStartupProject.csproj
+++ b/src/Sql.MigrationsStartupProject/Sql.MigrationsStartupProject.csproj
@@ -7,8 +7,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.3" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="8.0.3">
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="9.0.6" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="9.0.6">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/src/Sql.MigrationsStartupProject/Sql.MigrationsStartupProject.csproj
+++ b/src/Sql.MigrationsStartupProject/Sql.MigrationsStartupProject.csproj
@@ -7,8 +7,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="9.0.6" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="9.0.6">
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.0.10" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="10.0.10">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>


### PR DESCRIPTION
#### PR Classification
Upgrade and align codebase with latest .NET, EF Core, and CONTPAQi Comercial v12.1.0 schema.

#### PR Summary
The codebase is updated to support .NET 10.0 and the latest NuGet dependencies, with extensive changes to entity models and DbContext mappings to match the updated database schema.
- Project files: Upgraded target framework to .NET 10.0 and updated major NuGet package versions.
- SQL model files: Added new entity classes and extended existing ones with new properties.
- DbContext files (ContpaqiComercialEmpresaDbContext, ContpaqiComercialGeneralesDbContext): Added new DbSet properties, updated ModelBuilder configurations, and aligned property mappings, indexes, and constraints with the schema.
- Removed obsolete workaround code (e.g., RemoveDuplicateAnalyzers target).
- Updated project metadata for the new release.
